### PR TITLE
Feat responsive design for Seijaku List

### DIFF
--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/AppScaffold.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/AppScaffold.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.style.TextOverflow
 
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.yumedev.seijakulist.ui.theme.asp
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.yumedev.seijakulist.ui.navigation.AppDestinations
@@ -198,7 +199,7 @@ fun AppScaffold(
                                     text = "Seijaku List",
                                     color = MaterialTheme.colorScheme.onSurface,
                                     style = MaterialTheme.typography.titleLarge,
-                                    fontSize = 26.sp,
+                                    fontSize = 26.asp(),
                                     fontStyle = FontStyle.Italic,
                                 )
                             }
@@ -288,7 +289,7 @@ fun AppScaffold(
                                     Text(
                                         text = "Detalle del Personaje",
                                         fontFamily = PoppinsBold,
-                                        fontSize = 20.sp,
+                                        fontSize = 20.asp(),
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis
                                     )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/BackTopBar.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/BackTopBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.yumedev.seijakulist.R
+import com.yumedev.seijakulist.ui.theme.adp
 
 @Composable
 fun ArrowBackTopAppBar(
@@ -19,7 +20,7 @@ fun ArrowBackTopAppBar(
 ) {
     IconButton(
         onClick = { navController.popBackStack() },
-        modifier = Modifier.size(48.dp)
+        modifier = Modifier.size(48.adp())
     ) {
         Icon(
             painter = painterResource(id = R.drawable.ic_arrow_left_line),

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/BetaTestDialog.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/BetaTestDialog.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun BetaTestDialog(
@@ -64,7 +66,7 @@ fun BetaTestDialog(
                     contentDescription = "Prueba Beta",
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier
-                        .height(64.dp)
+                        .height(64.adp())
                         .padding(bottom = 8.dp)
                 )
 
@@ -72,7 +74,7 @@ fun BetaTestDialog(
                 Text(
                     text = "Prueba Cerrada Beta",
                     fontFamily = PoppinsBold,
-                    fontSize = 24.sp,
+                    fontSize = 24.asp(),
                     color = MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center
                 )
@@ -81,20 +83,20 @@ fun BetaTestDialog(
                 Text(
                     text = "Esta aplicación se encuentra en fase de desarrollo activo.",
                     fontFamily = PoppinsRegular,
-                    fontSize = 16.sp,
+                    fontSize = 16.asp(),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
                     textAlign = TextAlign.Center,
-                    lineHeight = 22.sp
+                    lineHeight = 22.asp()
                 )
 
                 // Advertencia
                 Text(
                     text = "Puede contener errores, bugs, comportamientos inesperados y componentes sin funcionalidades como botones, etc.",
                     fontFamily = PoppinsRegular,
-                    fontSize = 14.sp,
+                    fontSize = 14.asp(),
                     color = MaterialTheme.colorScheme.error,
                     textAlign = TextAlign.Center,
-                    lineHeight = 20.sp
+                    lineHeight = 20.asp()
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -103,19 +105,19 @@ fun BetaTestDialog(
                 Text(
                     text = "¡Gracias por ser parte de esta prueba cerrada!",
                     fontFamily = PoppinsBold,
-                    fontSize = 16.sp,
+                    fontSize = 16.asp(),
                     color = MaterialTheme.colorScheme.primary,
                     textAlign = TextAlign.Center,
-                    lineHeight = 22.sp
+                    lineHeight = 22.asp()
                 )
 
                 Text(
                     text = "Tus comentarios y reportes de errores son fundamentales para el desarrollo y mejora de SeijakuList.",
                     fontFamily = PoppinsRegular,
-                    fontSize = 14.sp,
+                    fontSize = 14.asp(),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                     textAlign = TextAlign.Center,
-                    lineHeight = 20.sp
+                    lineHeight = 20.asp()
                 )
 
                 Spacer(modifier = Modifier.height(12.dp))
@@ -138,17 +140,17 @@ fun BetaTestDialog(
                         Text(
                             text = "💙 Agradecimiento Especial",
                             fontFamily = PoppinsBold,
-                            fontSize = 15.sp,
+                            fontSize = 15.asp(),
                             color = MaterialTheme.colorScheme.onPrimaryContainer,
                             textAlign = TextAlign.Center
                         )
                         Text(
                             text = "Gracias a todos los testers que han dedicado su tiempo a probar la aplicación y reportar errores. Su ayuda es invaluable para hacer de SeijakuList una mejor experiencia.",
                             fontFamily = PoppinsRegular,
-                            fontSize = 13.sp,
+                            fontSize = 13.asp(),
                             color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.9f),
                             textAlign = TextAlign.Center,
-                            lineHeight = 18.sp
+                            lineHeight = 18.asp()
                         )
                     }
                 }
@@ -160,7 +162,7 @@ fun BetaTestDialog(
                     onClick = onDismiss,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(50.dp),
+                        .height(50.adp()),
                     shape = RoundedCornerShape(12.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.primary
@@ -169,7 +171,7 @@ fun BetaTestDialog(
                     Text(
                         text = "Continuar",
                         fontFamily = PoppinsBold,
-                        fontSize = 16.sp,
+                        fontSize = 16.asp(),
                         color = MaterialTheme.colorScheme.onPrimary
                     )
                 }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/BottomNavigationBar.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/BottomNavigationBar.kt
@@ -31,6 +31,8 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.yumedev.seijakulist.ui.theme.PoppinsMedium
 import com.yumedev.seijakulist.util.navigation_tools.BottomNavItem
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun BottomNavigationBar(navController: NavController, navItems: List<BottomNavItem>) {
@@ -65,7 +67,7 @@ fun BottomNavigationBar(navController: NavController, navItems: List<BottomNavIt
         Surface(
             modifier = Modifier
                 .fillMaxWidth(0.92f) // Efecto flotante (no toca los bordes laterales)
-                .height(72.dp)
+                .height(72.adp())
                 .shadow(
                     elevation = 20.dp,
                     shape = RoundedCornerShape(36.dp),
@@ -142,7 +144,7 @@ fun BottomNavigationBar(navController: NavController, navItems: List<BottomNavIt
                         modifier = Modifier
                             .weight(itemWeight)
                             .graphicsLayer(scaleX = scale, scaleY = scale)
-                            .height(48.dp)
+                            .height(48.adp())
                             .clip(RoundedCornerShape(24.dp))
                             .background(backgroundColor)
                             .clickable(
@@ -173,7 +175,7 @@ fun BottomNavigationBar(navController: NavController, navItems: List<BottomNavIt
                                 contentDescription = item.name,
                                 tint = contentColor,
                                 modifier = Modifier
-                                    .size(24.dp)
+                                    .size(24.adp())
                                     .offset(y = iconOffset) // Aplicamos el salto
                             )
 
@@ -195,7 +197,7 @@ fun BottomNavigationBar(navController: NavController, navItems: List<BottomNavIt
                                     style = MaterialTheme.typography.labelLarge.copy(
                                         fontFamily = PoppinsMedium,
                                         fontWeight = FontWeight.SemiBold,
-                                        fontSize = 14.sp
+                                        fontSize = 14.asp()
                                     ),
                                     color = contentColor,
                                     maxLines = 1,

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/BottomNavigationBar.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/BottomNavigationBar.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
@@ -81,7 +82,7 @@ fun BottomNavigationBar(navController: NavController, navItems: List<BottomNavIt
             Row(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 12.dp),
+                    .padding(horizontal = 8.dp),
                 horizontalArrangement = Arrangement.SpaceEvenly,
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -121,18 +122,34 @@ fun BottomNavigationBar(navController: NavController, navItems: List<BottomNavIt
                         label = "content_color"
                     )
 
+                    // 5. PESO DINÁMICO: el item seleccionado toma más espacio para mostrar el label
+                    val itemWeight by animateFloatAsState(
+                        targetValue = if (isSelected) 2.5f else 1f,
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioLowBouncy,
+                            stiffness = Spring.StiffnessLow
+                        ),
+                        label = "item_weight"
+                    )
+
+                    val itemPaddingHorizontal by animateDpAsState(
+                        targetValue = if (isSelected) 12.dp else 0.dp,
+                        animationSpec = tween(300),
+                        label = "item_padding"
+                    )
+
                     Box(
                         modifier = Modifier
-                            .graphicsLayer(scaleX = scale, scaleY = scale) // Aplicamos escala por GPU
+                            .weight(itemWeight)
+                            .graphicsLayer(scaleX = scale, scaleY = scale)
                             .height(48.dp)
                             .clip(RoundedCornerShape(24.dp))
                             .background(backgroundColor)
                             .clickable(
                                 interactionSource = interactionSource,
-                                indication = null, // Quitamos el ripple estándar para no ensuciar el diseño
+                                indication = null,
                                 onClick = {
                                     if (!isSelected) {
-                                        // Feedback háptico estilo iOS
                                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         navController.navigate(item.route) {
                                             popUpTo(navController.graph.findStartDestination().id) {
@@ -144,7 +161,7 @@ fun BottomNavigationBar(navController: NavController, navItems: List<BottomNavIt
                                     }
                                 }
                             )
-                            .padding(horizontal = 16.dp),
+                            .padding(horizontal = itemPaddingHorizontal),
                         contentAlignment = Alignment.Center
                     ) {
                         Row(
@@ -181,7 +198,9 @@ fun BottomNavigationBar(navController: NavController, navItems: List<BottomNavIt
                                         fontSize = 14.sp
                                     ),
                                     color = contentColor,
-                                    maxLines = 1
+                                    maxLines = 1,
+                                    softWrap = false,
+                                    overflow = TextOverflow.Ellipsis
                                 )
                             }
                         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/CardAnimeHomeLoading.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/CardAnimeHomeLoading.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.yumedev.seijakulist.ui.theme.adp
 
 @Composable
 fun CardAnimesHomeLoading() {
@@ -69,14 +70,14 @@ private fun AnimeCardSkeleton() {
     )
 
     Column(
-        modifier = Modifier.width(130.dp),
+        modifier = Modifier.width(130.adp()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // Imagen skeleton
         Box(
             modifier = Modifier
-                .width(130.dp)
-                .height(200.dp)
+                .width(130.adp())
+                .height(200.adp())
                 .clip(RoundedCornerShape(8.dp))
                 .background(brush)
         )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/CardAnimeRandom.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/CardAnimeRandom.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -56,7 +58,7 @@ fun AnimeRandomCard(
         onClick = { navController.navigate("${AppDestinations.ANIME_DETAIL_ROUTE}/${anime.malId}") },
         modifier = Modifier
             .fillMaxWidth()
-            .height(210.dp),
+            .height(210.adp()),
         shape = RoundedCornerShape(16.dp)
     ) {
         var isLiked by remember { mutableStateOf(false) }
@@ -79,8 +81,8 @@ fun AnimeRandomCard(
                     contentDescription = anime.title,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
-                        .width(140.dp)
-                        .height(210.dp)
+                        .width(140.adp())
+                        .height(210.adp())
                 )
                 Column(
                     modifier = Modifier
@@ -100,7 +102,7 @@ fun AnimeRandomCard(
                                 .padding(end = 40.dp)
                                 .fillMaxWidth(),
                             color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 18.sp,
+                            fontSize = 18.asp(),
                             fontFamily = PoppinsBold
                         )
                         Text(
@@ -109,7 +111,7 @@ fun AnimeRandomCard(
                             overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.padding(top = 4.dp),
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            fontSize = 13.sp,
+                            fontSize = 13.asp(),
                             fontFamily = PoppinsRegular,
                         )
                     }
@@ -163,7 +165,7 @@ fun AnimeRandomCard(
 fun GenreChip(text: String) {
     Text(
         text = text,
-        fontSize = 11.sp,
+        fontSize = 11.asp(),
         color = MaterialTheme.colorScheme.onSecondaryContainer,
         modifier = Modifier
             .background(

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/CardAnimesHome.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/CardAnimesHome.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -83,12 +85,12 @@ private fun AnimeSectionCard(
 
     Column(
         modifier = Modifier
-            .width(135.dp) // Un poquito más ancha para que luzca el arte
+            .width(135.adp())
             .clip(RoundedCornerShape(16.dp))
     ) {
         Box(
             modifier = Modifier
-                .height(200.dp)
+                .height(200.adp())
                 .fillMaxWidth()
                 .clickable {
                     navController.navigate("${AppDestinations.ANIME_DETAIL_ROUTE}/${anime.malId}")
@@ -112,7 +114,7 @@ private fun AnimeSectionCard(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(40.dp)
+                    .height(40.adp())
                     .background(
                         Brush.verticalGradient(
                             listOf(Color.Black.copy(alpha = 0.5f), Color.Transparent)
@@ -142,7 +144,7 @@ private fun AnimeSectionCard(
                     Text(
                         text = String.format("%.1f", anime.score),
                         color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 11.sp,
+                        fontSize = 11.asp(),
                         fontFamily = PoppinsBold
                     )
                 }
@@ -176,7 +178,7 @@ private fun AnimeSectionCard(
                     Text(
                         text = userStatus,
                         color = Color.White,
-                        fontSize = 9.sp,
+                        fontSize = 9.asp(),
                         fontFamily = PoppinsBold
                     )
                 }
@@ -192,8 +194,8 @@ private fun AnimeSectionCard(
             overflow = TextOverflow.Ellipsis,
             style = TextStyle(
                 fontFamily = PoppinsMedium, // Medium suele verse mejor que Regular en títulos
-                fontSize = 13.sp,
-                lineHeight = 18.sp,
+                fontSize = 13.asp(),
+                lineHeight = 18.asp(),
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.9f)
             ),
             modifier = Modifier.padding(horizontal = 4.dp)
@@ -234,7 +236,7 @@ fun CardAnimesHomeGrid(
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(195.dp)
+                .height(195.adp())
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh)
         )
 
@@ -242,7 +244,7 @@ fun CardAnimesHomeGrid(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(80.dp)
+                .height(80.adp())
                 .align(Alignment.BottomCenter)
                 .background(
                     Brush.verticalGradient(
@@ -258,8 +260,8 @@ fun CardAnimesHomeGrid(
             overflow = TextOverflow.Ellipsis,
             color = Color.White,
             fontFamily = PoppinsMedium,
-            fontSize = 11.sp,
-            lineHeight = 15.sp,
+            fontSize = 11.asp(),
+            lineHeight = 15.asp(),
             modifier = Modifier
                 .align(Alignment.BottomStart)
                 .padding(horizontal = 6.dp, vertical = 6.dp)
@@ -286,7 +288,7 @@ fun CardAnimesHomeGrid(
                 Text(
                     text = String.format("%.1f", anime.score),
                     color = Color.White,
-                    fontSize = 11.sp,
+                    fontSize = 11.asp(),
                     fontFamily = PoppinsBold
                 )
             }
@@ -321,7 +323,7 @@ fun CardAnimesHomeGrid(
                 Text(
                     text = userStatus,
                     color = Color.White,
-                    fontSize = 9.sp,
+                    fontSize = 9.asp(),
                     fontFamily = PoppinsBold
                 )
             }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/CardCharacterRandom.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/CardCharacterRandom.kt
@@ -56,6 +56,8 @@ import com.yumedev.seijakulist.domain.models.CharacterDetail
 import com.yumedev.seijakulist.ui.navigation.AppDestinations
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun CharacterRandomCard(
@@ -69,7 +71,7 @@ fun CharacterRandomCard(
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
-            .height(210.dp)
+            .height(210.adp())
             .clip(RoundedCornerShape(16.dp)),
         elevation = CardDefaults.cardElevation(
             defaultElevation = 16.dp
@@ -100,8 +102,8 @@ fun CharacterRandomCard(
                     contentDescription = "Imagen de portada",
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
-                        .width(140.dp)
-                        .height(210.dp)
+                        .width(140.adp())
+                        .height(210.adp())
                         .clip(RoundedCornerShape(16.dp))
                         .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
                 )
@@ -118,7 +120,7 @@ fun CharacterRandomCard(
                             .padding(start = 16.dp, top = 16.dp, end = 40.dp)
                             .fillMaxWidth(),
                         color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 18.sp,
+                        fontSize = 18.asp(),
                         fontFamily = PoppinsBold
                     )
                     Spacer(modifier = Modifier.height(8.dp))
@@ -140,7 +142,7 @@ fun CharacterRandomCard(
                                 .wrapContentWidth()
                                 .padding(end = 8.dp),
                             color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 16.sp,
+                            fontSize = 16.asp(),
                             fontFamily = PoppinsRegular
                         )
                         Text(
@@ -152,7 +154,7 @@ fun CharacterRandomCard(
                                 .wrapContentWidth()
                                 .padding(end = 16.dp),
                             color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 12.sp,
+                            fontSize = 12.asp(),
                             fontFamily = PoppinsRegular
                         )
                     }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/Charts.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/Charts.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import kotlin.math.min
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 data class PieChartData(
     val label: String,
@@ -74,14 +76,14 @@ fun DonutChart(
     ) {
         Box(
             modifier = Modifier
-                .size(260.dp)
+                .size(260.adp())
                 .padding(16.dp),
             contentAlignment = Alignment.Center
         ) {
             // Efecto de glow/brillo de fondo
             Canvas(
                 modifier = Modifier
-                    .size(220.dp)
+                    .size(220.adp())
             ) {
                 if (total > 0f) {
                     // Glow effect - múltiples círculos con opacidad decreciente
@@ -103,7 +105,7 @@ fun DonutChart(
 
             // Gráfico principal
             Canvas(
-                modifier = Modifier.size(200.dp)
+                modifier = Modifier.size(200.adp())
             ) {
                 if (total == 0f) return@Canvas
 
@@ -178,7 +180,7 @@ fun DonutChart(
             // Círculo central con gradiente para dar profundidad
             Surface(
                 modifier = Modifier
-                    .size(120.dp)
+                    .size(120.adp())
                     .shadow(4.dp, CircleShape),
                 shape = CircleShape,
                 color = MaterialTheme.colorScheme.surface
@@ -204,14 +206,14 @@ fun DonutChart(
                         ) {
                             Text(
                                 text = centerText,
-                                fontSize = 38.sp,
+                                fontSize = 38.asp(),
                                 fontFamily = PoppinsBold,
                                 color = MaterialTheme.colorScheme.onSurface
                             )
                             if (centerSubtext != null) {
                                 Text(
                                     text = centerSubtext,
-                                    fontSize = 12.sp,
+                                    fontSize = 12.asp(),
                                     fontFamily = PoppinsRegular,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     letterSpacing = 0.5.sp
@@ -285,7 +287,7 @@ private fun ChartLegendItem(
                 // Cuadrado de color con gradiente
                 Box(
                     modifier = Modifier
-                        .size(20.dp)
+                        .size(20.adp())
                         .shadow(2.dp, RoundedCornerShape(4.dp))
                         .background(
                             brush = Brush.linearGradient(
@@ -299,7 +301,7 @@ private fun ChartLegendItem(
                 )
                 Text(
                     text = label,
-                    fontSize = 16.sp,
+                    fontSize = 16.asp(),
                     fontFamily = PoppinsRegular,
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f)
@@ -312,13 +314,13 @@ private fun ChartLegendItem(
             ) {
                 Text(
                     text = String.format("%.1f%%", percentage),
-                    fontSize = 16.sp,
+                    fontSize = 16.asp(),
                     fontFamily = PoppinsBold,
                     color = color
                 )
                 Text(
                     text = "$value animes",
-                    fontSize = 12.sp,
+                    fontSize = 12.asp(),
                     fontFamily = PoppinsRegular,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/ChipStatus.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/ChipStatus.kt
@@ -41,6 +41,8 @@ import com.yumedev.seijakulist.ui.components.confirm_dialog.ConfirmResetEpisodes
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import com.yumedev.seijakulist.util.UserAction
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun AnimeStatusChip(
@@ -82,7 +84,7 @@ fun AnimeStatusChip(
                     text = status,
                     color = Color.White,
                     fontFamily = PoppinsBold,
-                    fontSize = 11.sp
+                    fontSize = 11.asp()
                 )
                 Icon(
                     imageVector = Icons.Default.KeyboardArrowDown,
@@ -103,7 +105,7 @@ fun AnimeStatusChip(
                 Text(
                     text = "Cambiar estado",
                     fontFamily = PoppinsBold,
-                    fontSize = 11.sp,
+                    fontSize = 11.asp(),
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
@@ -132,7 +134,7 @@ fun AnimeStatusChip(
                         Text(
                             text = newStatus,
                             fontFamily = PoppinsBold,
-                            fontSize = 13.sp,
+                            fontSize = 13.asp(),
                             color = itemColor
                         )
                     },
@@ -178,7 +180,7 @@ fun AnimeStatusChip(
                                 imageVector = statusIcon,
                                 contentDescription = newStatus,
                                 tint = itemColor,
-                                modifier = Modifier.size(20.dp)
+                                modifier = Modifier.size(20.adp())
                             )
                         }
                     },
@@ -188,7 +190,7 @@ fun AnimeStatusChip(
                                 imageVector = Icons.Default.Check,
                                 contentDescription = null,
                                 tint = itemColor,
-                                modifier = Modifier.size(16.dp)
+                                modifier = Modifier.size(16.adp())
                             )
                         }
                     },

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/CompleteAnimeRandomCard.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/CompleteAnimeRandomCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.yumedev.seijakulist.ui.screens.home.AnimeRandomUiState
 import com.yumedev.seijakulist.ui.screens.home.AnimeRandomViewModel
+import com.yumedev.seijakulist.ui.theme.adp
 
 @Composable
 fun CompleteAnimeCard(uiState: AnimeRandomUiState, navController: NavController, viewModel: AnimeRandomViewModel) {
@@ -32,7 +33,7 @@ fun CompleteAnimeCard(uiState: AnimeRandomUiState, navController: NavController,
         modifier = Modifier
             .padding(start = 10.dp, end = 10.dp, bottom = 16.dp)
             .fillMaxSize()
-            .height(210.dp)
+            .height(210.adp())
             .clip(RoundedCornerShape(16.dp))
             .background(color = MaterialTheme.colorScheme.surfaceContainerHigh),
         contentAlignment = Alignment.Center

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/CompleteCharacterCard.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/CompleteCharacterCard.kt
@@ -26,6 +26,7 @@ import com.yumedev.seijakulist.ui.screens.home.AnimeRandomUiState
 import com.yumedev.seijakulist.ui.screens.home.AnimeRandomViewModel
 import com.yumedev.seijakulist.ui.screens.home.CharacterRandomUiState
 import com.yumedev.seijakulist.ui.screens.home.CharacterRandomViewModel
+import com.yumedev.seijakulist.ui.theme.adp
 
 @Composable
 fun CompleteCharacterCard(uiState: CharacterRandomUiState, navController: NavController, viewModel: CharacterRandomViewModel) {
@@ -34,7 +35,7 @@ fun CompleteCharacterCard(uiState: CharacterRandomUiState, navController: NavCon
         modifier = Modifier
             .padding(start = 10.dp, end = 10.dp, bottom = 16.dp)
             .fillMaxSize()
-            .height(210.dp)
+            .height(210.adp())
             .clip(RoundedCornerShape(16.dp))
             .background(
                 color = MaterialTheme.colorScheme.surfaceContainerHigh

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/CustomDialog.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/CustomDialog.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 /**
  * Tipos de diálogo predefinidos con iconos y colores correspondientes
@@ -128,14 +130,14 @@ fun CustomDialog(
                     imageVector = icon,
                     contentDescription = title,
                     tint = iconTint,
-                    modifier = Modifier.size(64.dp)
+                    modifier = Modifier.size(64.adp())
                 )
 
                 // Título
                 Text(
                     text = title,
                     fontFamily = PoppinsBold,
-                    fontSize = 22.sp,
+                    fontSize = 22.asp(),
                     color = MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center
                 )
@@ -144,10 +146,10 @@ fun CustomDialog(
                 Text(
                     text = message,
                     fontFamily = PoppinsRegular,
-                    fontSize = 15.sp,
+                    fontSize = 15.asp(),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
                     textAlign = TextAlign.Center,
-                    lineHeight = 21.sp
+                    lineHeight = 21.asp()
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -166,7 +168,7 @@ fun CustomDialog(
                             },
                             modifier = Modifier
                                 .weight(1f)
-                                .height(48.dp),
+                                .height(48.adp()),
                             shape = RoundedCornerShape(12.dp),
                             colors = ButtonDefaults.outlinedButtonColors(
                                 contentColor = MaterialTheme.colorScheme.onSurface
@@ -175,7 +177,7 @@ fun CustomDialog(
                             Text(
                                 text = dismissButtonText,
                                 fontFamily = PoppinsBold,
-                                fontSize = 15.sp
+                                fontSize = 15.asp()
                             )
                         }
                     }
@@ -188,7 +190,7 @@ fun CustomDialog(
                         },
                         modifier = Modifier
                             .weight(1f)
-                            .height(48.dp),
+                            .height(48.adp()),
                         shape = RoundedCornerShape(12.dp),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = if (type == DialogType.ERROR || type == DialogType.DELETE) {
@@ -206,7 +208,7 @@ fun CustomDialog(
                         Text(
                             text = confirmButtonText,
                             fontFamily = PoppinsBold,
-                            fontSize = 15.sp
+                            fontSize = 15.asp()
                         )
                     }
                 }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/DeleteMyAnime.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/DeleteMyAnime.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
 
 @Composable
 fun DeleteMyAnime(
@@ -39,13 +40,13 @@ fun DeleteMyAnime(
         IconButton(
             onClick = { isMenuExpanded = true },
             modifier = Modifier
-                .size(24.dp)
+                .size(24.adp())
         ) {
             Icon(
                 imageVector = Icons.Default.MoreVert,
                 contentDescription = "Opciones",
                 tint = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(24.adp())
             )
         }
 

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/DescriptionAnime.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/DescriptionAnime.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.yumedev.seijakulist.ui.theme.adp
 
 @Composable
 fun DescriptionAnime(icon: ImageVector, title: String, description: String) {
@@ -41,7 +42,7 @@ fun DescriptionAnime(icon: ImageVector, title: String, description: String) {
             Icon(
                 imageVector = icon,
                 contentDescription = null,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(20.adp()),
                 tint = MaterialTheme.colorScheme.primary
             )
             Text(

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/DeveloperInfoDialog.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/DeveloperInfoDialog.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun DeveloperInfoDialog(
@@ -74,7 +76,7 @@ fun DeveloperInfoDialog(
                     Text(
                         text = "Desarrollador",
                         fontFamily = PoppinsBold,
-                        fontSize = 24.sp,
+                        fontSize = 24.asp(),
                         color = MaterialTheme.colorScheme.onSurface,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.weight(1f)
@@ -82,7 +84,7 @@ fun DeveloperInfoDialog(
 
                     IconButton(
                         onClick = onDismiss,
-                        modifier = Modifier.size(40.dp)
+                        modifier = Modifier.size(40.adp())
                     ) {
                         Icon(
                             imageVector = Icons.Default.Close,
@@ -97,14 +99,14 @@ fun DeveloperInfoDialog(
                     imageVector = Icons.Default.Code,
                     contentDescription = "Acerca de",
                     tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(64.dp)
+                    modifier = Modifier.size(64.adp())
                 )
 
                 // Nombre
                 Text(
                     text = "Bustamante Pedro",
                     fontFamily = PoppinsBold,
-                    fontSize = 20.sp,
+                    fontSize = 20.asp(),
                     color = MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center
                 )
@@ -113,10 +115,10 @@ fun DeveloperInfoDialog(
                 Text(
                     text = "Hola! Soy el desarrollador de Seijaku List (una app personal de registro de anime/manga en desarrollo activo).\n\nMe desenvuelvo profesionalmente como Desarrollador Android y me entusiasma combinar mis intereses: la programación, la música y el anime.\n\nDato curioso: Mi anime favorito es K-On!",
                     fontFamily = PoppinsRegular,
-                    fontSize = 14.sp,
+                    fontSize = 14.asp(),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                     textAlign = TextAlign.Justify,
-                    lineHeight = 20.sp
+                    lineHeight = 20.asp()
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -125,7 +127,7 @@ fun DeveloperInfoDialog(
                 Text(
                     text = "Redes Sociales",
                     fontFamily = PoppinsBold,
-                    fontSize = 16.sp,
+                    fontSize = 16.asp(),
                     color = MaterialTheme.colorScheme.primary,
                     textAlign = TextAlign.Center
                 )
@@ -197,13 +199,13 @@ private fun SocialMediaLink(
             imageVector = icon,
             contentDescription = label,
             tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(24.dp)
+            modifier = Modifier.size(24.adp())
         )
 
         Text(
             text = label,
             fontFamily = PoppinsRegular,
-            fontSize = 16.sp,
+            fontSize = 16.asp(),
             color = MaterialTheme.colorScheme.onSurface
         )
     }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/FilterTopBar.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/FilterTopBar.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.data.local.entities.AnimeEntity
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun FilterTopAppBar(
@@ -63,7 +65,7 @@ fun FilterTopAppBar(
             shape = RoundedCornerShape(12.dp),
             color = if (expanded) MaterialTheme.colorScheme.primaryContainer
                    else MaterialTheme.colorScheme.surface,
-            modifier = Modifier.size(48.dp)
+            modifier = Modifier.size(48.adp())
         ) {
             Box(contentAlignment = Alignment.Center) {
                 Icon(
@@ -71,7 +73,7 @@ fun FilterTopAppBar(
                     contentDescription = "Opciones",
                     tint = if (expanded) MaterialTheme.colorScheme.onPrimaryContainer
                            else MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.size(24.dp)
+                    modifier = Modifier.size(24.adp())
                 )
             }
         }
@@ -83,7 +85,7 @@ fun FilterTopAppBar(
             offset = DpOffset(x = (-8).dp, y = 8.dp),
             shape = RoundedCornerShape(16.dp),
             modifier = Modifier
-                .width(240.dp)
+                .width(240.adp())
                 .background(
                     color = MaterialTheme.colorScheme.surfaceContainer,
                     shape = RoundedCornerShape(16.dp)
@@ -106,7 +108,7 @@ fun FilterTopAppBar(
                     text = "Personaliza tu lista",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 11.sp
+                    fontSize = 11.asp()
                 )
             }
 
@@ -131,7 +133,7 @@ fun FilterTopAppBar(
                             text = "Encuentra animes rápidamente",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            fontSize = 11.sp
+                            fontSize = 11.asp()
                         )
                     }
                 },
@@ -143,14 +145,14 @@ fun FilterTopAppBar(
                     Surface(
                         shape = RoundedCornerShape(8.dp),
                         color = MaterialTheme.colorScheme.primaryContainer,
-                        modifier = Modifier.size(40.dp)
+                        modifier = Modifier.size(40.adp())
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             Icon(
                                 imageVector = Icons.Default.Search,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                                modifier = Modifier.size(20.dp)
+                                modifier = Modifier.size(20.adp())
                             )
                         }
                     }
@@ -185,7 +187,7 @@ fun FilterTopAppBar(
                             },
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            fontSize = 11.sp
+                            fontSize = 11.asp()
                         )
                     }
                 },
@@ -197,7 +199,7 @@ fun FilterTopAppBar(
                     Surface(
                         shape = RoundedCornerShape(8.dp),
                         color = MaterialTheme.colorScheme.secondaryContainer,
-                        modifier = Modifier.size(40.dp)
+                        modifier = Modifier.size(40.adp())
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             Icon(
@@ -208,7 +210,7 @@ fun FilterTopAppBar(
                                 },
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                                modifier = Modifier.size(20.dp)
+                                modifier = Modifier.size(20.adp())
                             )
                         }
                     }
@@ -243,7 +245,7 @@ fun FilterTopAppBar(
                             },
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            fontSize = 11.sp
+                            fontSize = 11.asp()
                         )
                     }
                 },
@@ -257,14 +259,14 @@ fun FilterTopAppBar(
                         color = if (sortOrder != com.yumedev.seijakulist.ui.components.SortOrder.NONE)
                                     MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.8f)
                                 else MaterialTheme.colorScheme.tertiaryContainer,
-                        modifier = Modifier.size(40.dp)
+                        modifier = Modifier.size(40.adp())
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             Icon(
                                 imageVector = Icons.Default.SortByAlpha,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onTertiaryContainer,
-                                modifier = Modifier.size(20.dp)
+                                modifier = Modifier.size(20.adp())
                             )
                         }
                     }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/FilterTopBarMangas.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/FilterTopBarMangas.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import com.yumedev.seijakulist.ui.theme.adp
 
 @Composable
 fun FilterTopAppBarMangas(onSearchClick: () -> Unit) {
@@ -33,7 +34,7 @@ fun FilterTopAppBarMangas(onSearchClick: () -> Unit) {
             onClick = {
                 expanded = !expanded
             },
-            modifier = Modifier.size(48.dp)
+            modifier = Modifier.size(48.adp())
         ) {
             Icon(
                 imageVector = Icons.Default.Dehaze,

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/LoadingScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/LoadingScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.ui.theme.PoppinsMedium
 import kotlinx.coroutines.delay
+import com.yumedev.seijakulist.ui.theme.adp
 
 @Composable
 fun LoadingScreen() {
@@ -39,7 +40,7 @@ fun LoadingScreen() {
         contentAlignment = Alignment.Center
     ) {
         androidx.compose.material3.CircularProgressIndicator(
-            modifier = Modifier.size(48.dp),
+            modifier = Modifier.size(48.adp()),
             color = MaterialTheme.colorScheme.primary,
             strokeWidth = 4.dp
         )
@@ -77,7 +78,7 @@ private fun AnimatedLoadingDots() {
         dots.forEach { animatable ->
             Box(
                 modifier = Modifier
-                    .size(16.dp)
+                    .size(16.adp())
                     .scale(0.5f + (animatable.value * 0.5f))
                     .alpha(0.4f + (animatable.value * 0.6f))
                     .background(
@@ -108,7 +109,7 @@ fun CustomCircularLoading() {
     }
 
     Canvas(
-        modifier = Modifier.size(56.dp)
+        modifier = Modifier.size(56.adp())
     ) {
         val strokeWidth = 4.dp.toPx()
 

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/MangaPlaceholder.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/MangaPlaceholder.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun MangaPlaceholder() {
@@ -33,14 +35,14 @@ fun MangaPlaceholder() {
         Icon(
             imageVector = Icons.AutoMirrored.Filled.MenuBook,
             contentDescription = null,
-            modifier = Modifier.size(80.dp),
+            modifier = Modifier.size(80.adp()),
             tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
         )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
             text = "Próximamente",
             fontFamily = PoppinsBold,
-            fontSize = 24.sp,
+            fontSize = 24.asp(),
             color = MaterialTheme.colorScheme.onSurface
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -48,9 +50,9 @@ fun MangaPlaceholder() {
             text = "Estamos trabajando para traerte lo mejor del manga",
             fontFamily = PoppinsRegular,
             textAlign = TextAlign.Center,
-            fontSize = 15.sp,
+            fontSize = 15.asp(),
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-            lineHeight = 22.sp
+            lineHeight = 22.asp()
         )
     }
 }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/NoInternetScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/NoInternetScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsMedium
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun NoInternetScreen(
@@ -52,7 +54,7 @@ fun NoInternetScreen(
         // Título principal
         Text(
             text = "¡Oops!",
-            fontSize = 32.sp,
+            fontSize = 32.asp(),
             fontFamily = PoppinsBold,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center
@@ -63,7 +65,7 @@ fun NoInternetScreen(
         // Mensaje descriptivo
         Text(
             text = "Parece que hay un problema",
-            fontSize = 18.sp,
+            fontSize = 18.asp(),
             fontFamily = PoppinsMedium,
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
             textAlign = TextAlign.Center
@@ -74,20 +76,20 @@ fun NoInternetScreen(
         // Mensaje de ayuda
         Text(
             text = "Verifica tu conexión a internet\ne intenta nuevamente",
-            fontSize = 14.sp,
+            fontSize = 14.asp(),
             fontFamily = PoppinsRegular,
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
             textAlign = TextAlign.Center,
-            lineHeight = 22.sp
+            lineHeight = 22.asp()
         )
 
-        Spacer(modifier = Modifier.height(40.dp))
+        Spacer(modifier = Modifier.height(40.adp()))
 
         // Botón mejorado
         Button(
             onClick = onRetryClick,
             modifier = Modifier
-                .height(56.dp)
+                .height(56.adp())
                 .padding(horizontal = 16.dp),
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.primary,
@@ -102,12 +104,12 @@ fun NoInternetScreen(
             Icon(
                 imageVector = Icons.Default.Refresh,
                 contentDescription = null,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(20.adp())
             )
             Spacer(modifier = Modifier.size(8.dp))
             Text(
                 text = "Reintentar",
-                fontSize = 16.sp,
+                fontSize = 16.asp(),
                 fontFamily = PoppinsMedium
             )
         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/SubTitleWithIcon.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/SubTitleWithIcon.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.R
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import java.nio.file.WatchEvent
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun SubTitleIcon(subTitle: String, icon: ImageVector) {
@@ -45,7 +46,7 @@ fun SubTitleIcon(subTitle: String, icon: ImageVector) {
         Text(
             text = subTitle,
             color = MaterialTheme.colorScheme.onSurface,
-            fontSize = 20.sp,
+            fontSize = 20.asp(),
             fontFamily = PoppinsBold,
             modifier = Modifier.weight(1f),
             textAlign = TextAlign.Start

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/SubTitleWithoutIcon.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/SubTitleWithoutIcon.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.R
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun SubTitleWithoutIcon(subTitle: String) {
@@ -38,7 +39,7 @@ fun SubTitleWithoutIcon(subTitle: String) {
         Text(
             text = subTitle,
             color = MaterialTheme.colorScheme.onSurface,
-            fontSize = 22.sp,
+            fontSize = 22.asp(),
             fontFamily = PoppinsBold,
             textAlign = TextAlign.Start,
         )
@@ -48,7 +49,7 @@ fun SubTitleWithoutIcon(subTitle: String) {
             Text(
                 text = "Ver más",
                 color = MaterialTheme.colorScheme.primary,
-                fontSize = 14.sp,
+                fontSize = 14.asp(),
                 fontFamily = PoppinsRegular,
             )
         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/TitleWithPadding.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/TitleWithPadding.kt
@@ -9,13 +9,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun TitleWithPadding(title: String) {
     Text(
         text = title,
         color = MaterialTheme.colorScheme.onSurface,
-        fontSize = 24.sp,
+        fontSize = 24.asp(),
         textAlign = TextAlign.Center,
         modifier = Modifier
             .padding(start = 16.dp, top = 16.dp, bottom = 16.dp),

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/Tittle.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/Tittle.kt
@@ -13,13 +13,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun TitleScreen(title: String) {
     Text(
         text = title,
         color = MaterialTheme.colorScheme.onSurface,
-        fontSize = 24.sp,
+        fontSize = 24.asp(),
         textAlign = TextAlign.Center,
         modifier = Modifier,
         fontFamily = PoppinsBold

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/WhatsNewBanner.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/WhatsNewBanner.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun WhatsNewBanner(
@@ -79,21 +81,21 @@ fun WhatsNewBanner(
                     imageVector = Icons.Default.AutoAwesome,
                     contentDescription = null,
                     tint = contentColor,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(20.adp())
                 )
 
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = "¡Seijaku List se actualizó!",
                         fontFamily = PoppinsBold,
-                        fontSize = 13.sp,
+                        fontSize = 13.asp(),
                         color = contentColor,
-                        lineHeight = 16.sp
+                        lineHeight = 16.asp()
                     )
                     Text(
                         text = "v$versionName · Mirá las novedades",
                         fontFamily = PoppinsRegular,
-                        fontSize = 11.sp,
+                        fontSize = 11.asp(),
                         color = contentColor.copy(alpha = 0.65f)
                     )
                 }
@@ -110,7 +112,7 @@ fun WhatsNewBanner(
                     Text(
                         text = "Ver",
                         fontFamily = PoppinsBold,
-                        fontSize = 11.sp,
+                        fontSize = 11.asp(),
                         color = contentColor
                     )
                     Icon(
@@ -123,7 +125,7 @@ fun WhatsNewBanner(
 
                 Box(
                     modifier = Modifier
-                        .size(28.dp)
+                        .size(28.adp())
                         .clip(CircleShape)
                         .background(contentColor.copy(alpha = 0.10f))
                         .clickable(onClick = onDismiss),

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/custom/AnimeButton.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/custom/AnimeButton.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 /**
  * Botón personalizado con estilo Anime/Manga
@@ -114,7 +116,7 @@ fun AnimeButton(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(60.dp)
+            .height(60.adp())
             .scale(scale.value)
             .shadow(
                 elevation = if (isPressed) 2.dp else 8.dp,
@@ -169,14 +171,14 @@ fun AnimeButton(
                     imageVector = icon,
                     contentDescription = null,
                     tint = if (enabled) textColor else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
-                    modifier = Modifier.size(24.dp)
+                    modifier = Modifier.size(24.adp())
                 )
                 Spacer(modifier = Modifier.width(12.dp))
             }
 
             Text(
                 text = text,
-                fontSize = 18.sp,
+                fontSize = 18.asp(),
                 fontFamily = PoppinsBold,
                 color = if (enabled) textColor else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
                 letterSpacing = 0.5.sp

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/custom/AnimeDecorations.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/custom/AnimeDecorations.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.yumedev.seijakulist.ui.theme.adp
 
 enum class BlobPosition { TopEnd, BottomStart }
 
@@ -40,7 +41,7 @@ fun AuthBlobDecoration(
                 // Círculo grande detrás (mayormente fuera de pantalla)
                 Box(
                     modifier = Modifier
-                        .size(240.dp)
+                        .size(240.adp())
                         .align(Alignment.TopEnd)
                         .offset(x = 80.dp, y = (-90).dp)
                         .background(color.copy(alpha = 0.25f), CircleShape)
@@ -48,7 +49,7 @@ fun AuthBlobDecoration(
                 // Círculo mediano
                 Box(
                     modifier = Modifier
-                        .size(185.dp)
+                        .size(185.adp())
                         .align(Alignment.TopEnd)
                         .offset(x = 25.dp, y = 55.dp)
                         .background(color.copy(alpha = 0.42f), CircleShape)
@@ -56,7 +57,7 @@ fun AuthBlobDecoration(
                 // Círculo pequeño al frente
                 Box(
                     modifier = Modifier
-                        .size(135.dp)
+                        .size(135.adp())
                         .align(Alignment.TopEnd)
                         .offset(x = 55.dp, y = (-15).dp)
                         .background(color.copy(alpha = 0.65f), CircleShape)
@@ -66,7 +67,7 @@ fun AuthBlobDecoration(
                 // Círculo grande detrás
                 Box(
                     modifier = Modifier
-                        .size(270.dp)
+                        .size(270.adp())
                         .align(Alignment.BottomStart)
                         .offset(x = (-85).dp, y = 85.dp)
                         .background(color.copy(alpha = 0.25f), CircleShape)
@@ -74,7 +75,7 @@ fun AuthBlobDecoration(
                 // Círculo mediano
                 Box(
                     modifier = Modifier
-                        .size(210.dp)
+                        .size(210.adp())
                         .align(Alignment.BottomStart)
                         .offset(x = 55.dp, y = 55.dp)
                         .background(color.copy(alpha = 0.42f), CircleShape)
@@ -82,7 +83,7 @@ fun AuthBlobDecoration(
                 // Círculo pequeño al frente
                 Box(
                     modifier = Modifier
-                        .size(155.dp)
+                        .size(155.adp())
                         .align(Alignment.BottomStart)
                         .offset(x = (-18).dp, y = 22.dp)
                         .background(color.copy(alpha = 0.65f), CircleShape)
@@ -119,7 +120,7 @@ fun AnimeGradientBackground(
         Box(
             modifier = Modifier
                 .offset(x = 200.dp, y = (-50).dp)
-                .size(300.dp)
+                .size(300.adp())
                 .background(
                     brush = Brush.radialGradient(
                         colors = listOf(
@@ -135,7 +136,7 @@ fun AnimeGradientBackground(
         Box(
             modifier = Modifier
                 .offset(x = (-100).dp, y = 500.dp)
-                .size(250.dp)
+                .size(250.adp())
                 .background(
                     brush = Brush.radialGradient(
                         colors = listOf(

--- a/app/src/main/java/com/yumedev/seijakulist/ui/components/custom/AnimeTextField.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/components/custom/AnimeTextField.kt
@@ -50,6 +50,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 /**
  * TextField personalizado con estilo Anime/Manga
@@ -110,7 +112,7 @@ fun AnimeTextField(
             Text(
                 text = label,
                 fontFamily = PoppinsBold,
-                fontSize = 15.sp,
+                fontSize = 15.asp(),
                 color = if (isError) {
                     MaterialTheme.colorScheme.error
                 } else {
@@ -124,7 +126,7 @@ fun AnimeTextField(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(60.dp)
+                .height(60.adp())
                 .shadow(
                     elevation = if (isFocused) 8.dp else 2.dp,
                     shape = RoundedCornerShape(12.dp),
@@ -179,7 +181,7 @@ fun AnimeTextField(
                         } else {
                             MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                         },
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(24.adp())
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                 }
@@ -194,7 +196,7 @@ fun AnimeTextField(
                             .onFocusChanged { isFocused = it.isFocused },
                         textStyle = LocalTextStyle.current.copy(
                             color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 16.sp,
+                            fontSize = 16.asp(),
                             fontFamily = PoppinsRegular
                         ),
                         visualTransformation = visualTransformation,
@@ -208,7 +210,7 @@ fun AnimeTextField(
                                     text = placeholder,
                                     style = TextStyle(
                                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
-                                        fontSize = 16.sp,
+                                        fontSize = 16.asp(),
                                         fontFamily = PoppinsRegular
                                     )
                                 )
@@ -243,12 +245,12 @@ fun AnimeTextField(
             ) {
                 Text(
                     text = "⚠️",
-                    fontSize = 14.sp
+                    fontSize = 14.asp()
                 )
                 Text(
                     text = errorMessage ?: "",
                     color = MaterialTheme.colorScheme.error,
-                    fontSize = 13.sp,
+                    fontSize = 13.asp(),
                     fontFamily = PoppinsRegular
                 )
             }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/AnimeLoginScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/AnimeLoginScreen.kt
@@ -64,6 +64,8 @@ import com.yumedev.seijakulist.ui.navigation.AppDestinations
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import kotlinx.coroutines.delay
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun AnimeLoginScreen(
@@ -158,7 +160,7 @@ fun AnimeLoginScreen(
                 .padding(horizontal = 28.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Spacer(modifier = Modifier.height(60.dp))
+            Spacer(modifier = Modifier.height(60.adp()))
 
             // Logo/Título con animación
             Column(
@@ -170,7 +172,7 @@ fun AnimeLoginScreen(
                 // Título principal con gradiente
                 Text(
                     text = "SeijakuList",
-                    fontSize = 52.sp,
+                    fontSize = 52.asp(),
                     fontFamily = PoppinsBold,
                     fontStyle = FontStyle.Italic,
                     style = MaterialTheme.typography.displayLarge.copy(
@@ -199,7 +201,7 @@ fun AnimeLoginScreen(
 
                     Text(
                         text = "アニメリスト",
-                        fontSize = 14.sp,
+                        fontSize = 14.asp(),
                         fontFamily = PoppinsRegular,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                         letterSpacing = 2.sp
@@ -213,7 +215,7 @@ fun AnimeLoginScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.height(50.dp))
+            Spacer(modifier = Modifier.height(50.adp()))
 
             // Mensaje de bienvenida
             Column(
@@ -223,7 +225,7 @@ fun AnimeLoginScreen(
                 Text(
                     text = "¡Bienvenido de nuevo!",
                     fontFamily = PoppinsBold,
-                    fontSize = 26.sp,
+                    fontSize = 26.asp(),
                     color = MaterialTheme.colorScheme.onSurface
                 )
 
@@ -232,13 +234,13 @@ fun AnimeLoginScreen(
                 Text(
                     text = "Ingresa a tu cuenta para continuar",
                     fontFamily = PoppinsRegular,
-                    fontSize = 15.sp,
+                    fontSize = 15.asp(),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                     textAlign = TextAlign.Center
                 )
             }
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
 
             // Formulario
             AnimeTextField(
@@ -297,7 +299,7 @@ fun AnimeLoginScreen(
                         text = "¿Olvidaste tu contraseña?",
                         fontFamily = PoppinsRegular,
                         color = MaterialTheme.colorScheme.primary,
-                        fontSize = 14.sp
+                        fontSize = 14.asp()
                     )
                 }
             }
@@ -333,13 +335,13 @@ fun AnimeLoginScreen(
                     Text(
                         text = "⚠️ ${(authResult as AuthResult.Error).message}",
                         color = MaterialTheme.colorScheme.error,
-                        fontSize = 14.sp,
+                        fontSize = 14.asp(),
                         fontFamily = PoppinsRegular
                     )
                 }
             }
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
 
             // Registro
             Row(
@@ -351,7 +353,7 @@ fun AnimeLoginScreen(
                     text = "¿No tienes cuenta?",
                     fontFamily = PoppinsRegular,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                    fontSize = 15.sp
+                    fontSize = 15.asp()
                 )
 
                 TextButton(
@@ -361,12 +363,12 @@ fun AnimeLoginScreen(
                         text = "Regístrate",
                         fontFamily = PoppinsBold,
                         color = MaterialTheme.colorScheme.primary,
-                        fontSize = 15.sp
+                        fontSize = 15.asp()
                     )
                 }
             }
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
         }
     }
 }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/AnimeRegisterScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/AnimeRegisterScreen.kt
@@ -66,6 +66,8 @@ import com.yumedev.seijakulist.ui.components.custom.SakuraFlower
 import com.yumedev.seijakulist.ui.navigation.AppDestinations
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun AnimeRegisterScreen(
@@ -159,7 +161,7 @@ fun AnimeRegisterScreen(
                 .padding(horizontal = 28.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
 
             // Botón de volver
             Row(
@@ -171,7 +173,7 @@ fun AnimeRegisterScreen(
                         painter = painterResource(id = R.drawable.ic_arrow_left_line),
                         contentDescription = "Volver",
                         tint = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.size(28.dp)
+                        modifier = Modifier.size(28.adp())
                     )
                 }
             }
@@ -187,7 +189,7 @@ fun AnimeRegisterScreen(
             ) {
                 Text(
                     text = "SeijakuList",
-                    fontSize = 48.sp,
+                    fontSize = 48.asp(),
                     fontFamily = PoppinsBold,
                     fontStyle = FontStyle.Italic,
                     style = MaterialTheme.typography.displayLarge.copy(
@@ -215,7 +217,7 @@ fun AnimeRegisterScreen(
 
                     Text(
                         text = "アニメリスト",
-                        fontSize = 14.sp,
+                        fontSize = 14.asp(),
                         fontFamily = PoppinsRegular,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                         letterSpacing = 2.sp
@@ -229,7 +231,7 @@ fun AnimeRegisterScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
 
             // Mensaje de bienvenida
             Column(
@@ -239,7 +241,7 @@ fun AnimeRegisterScreen(
                 Text(
                     text = "¡Únete a la comunidad!",
                     fontFamily = PoppinsBold,
-                    fontSize = 26.sp,
+                    fontSize = 26.asp(),
                     color = MaterialTheme.colorScheme.onSurface
                 )
 
@@ -248,13 +250,13 @@ fun AnimeRegisterScreen(
                 Text(
                     text = "Crea tu cuenta y comienza tu aventura",
                     fontFamily = PoppinsRegular,
-                    fontSize = 15.sp,
+                    fontSize = 15.asp(),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                     textAlign = TextAlign.Center
                 )
             }
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
 
             // Formulario
             AnimeTextField(
@@ -366,13 +368,13 @@ fun AnimeRegisterScreen(
                     Text(
                         text = "⚠️ ${(authResult as AuthResult.Error).message}",
                         color = MaterialTheme.colorScheme.error,
-                        fontSize = 14.sp,
+                        fontSize = 14.asp(),
                         fontFamily = PoppinsRegular
                     )
                 }
             }
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
 
             // Login
             Row(
@@ -384,7 +386,7 @@ fun AnimeRegisterScreen(
                     text = "¿Ya tienes cuenta?",
                     fontFamily = PoppinsRegular,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                    fontSize = 15.sp
+                    fontSize = 15.asp()
                 )
 
                 TextButton(
@@ -394,12 +396,12 @@ fun AnimeRegisterScreen(
                         text = "Inicia sesión",
                         fontFamily = PoppinsBold,
                         color = MaterialTheme.colorScheme.primary,
-                        fontSize = 15.sp
+                        fontSize = 15.asp()
                     )
                 }
             }
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
         }
     }
 }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/AuthScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/AuthScreen.kt
@@ -46,6 +46,8 @@ import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 data class OnboardingPage(
     val title: String,
@@ -195,7 +197,7 @@ fun AuthScreen(
                         },
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(56.dp),
+                            .height(56.adp()),
                         shape = RoundedCornerShape(16.dp),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = pages[pagerState.currentPage].color
@@ -208,12 +210,12 @@ fun AuthScreen(
                             Text(
                                 text = if (pagerState.currentPage == pages.size - 1) "Comenzar" else "Siguiente",
                                 fontFamily = PoppinsBold,
-                                fontSize = 16.sp
+                                fontSize = 16.asp()
                             )
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                                 contentDescription = null,
-                                modifier = Modifier.size(20.dp)
+                                modifier = Modifier.size(20.adp())
                             )
                         }
                     }
@@ -345,7 +347,7 @@ private fun OnboardingPageContent(
                 }
             }
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
 
             // Título
             AnimatedVisibility(
@@ -358,10 +360,10 @@ private fun OnboardingPageContent(
                 Text(
                     text = page.title,
                     fontFamily = PoppinsBold,
-                    fontSize = 30.sp,
+                    fontSize = 30.asp(),
                     color = MaterialTheme.colorScheme.onBackground,
                     textAlign = TextAlign.Center,
-                    lineHeight = 36.sp,
+                    lineHeight = 36.asp(),
                     letterSpacing = 0.3.sp
                 )
             }
@@ -394,10 +396,10 @@ private fun OnboardingPageContent(
                     Text(
                         text = page.description,
                         fontFamily = PoppinsRegular,
-                        fontSize = 15.sp,
+                        fontSize = 15.asp(),
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
                         textAlign = TextAlign.Center,
-                        lineHeight = 22.sp,
+                        lineHeight = 22.asp(),
                         letterSpacing = 0.2.sp
                     )
                 }
@@ -412,7 +414,7 @@ private fun AnimeCardPreview(accentColor: Color) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(280.dp),
+            .height(280.adp()),
         contentAlignment = Alignment.Center
     ) {
         // Card trasera izquierda - K-On!
@@ -511,7 +513,7 @@ private fun AnimeCardPreview(accentColor: Color) {
                             Text(
                                 text = "TV",
                                 fontFamily = PoppinsBold,
-                                fontSize = 9.sp,
+                                fontSize = 9.asp(),
                                 color = Color.White,
                                 modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp)
                             )
@@ -535,7 +537,7 @@ private fun AnimeCardPreview(accentColor: Color) {
                                 Text(
                                     text = "9.3",
                                     fontFamily = PoppinsBold,
-                                    fontSize = 11.sp,
+                                    fontSize = 11.asp(),
                                     color = Color.White
                                 )
                             }
@@ -548,7 +550,7 @@ private fun AnimeCardPreview(accentColor: Color) {
                         Text(
                             text = "Sousou no Frieren",
                             fontFamily = PoppinsBold,
-                            fontSize = 13.sp,
+                            fontSize = 13.asp(),
                             color = Color.White
                         )
 
@@ -573,7 +575,7 @@ private fun AnimeCardPreview(accentColor: Color) {
                                     Text(
                                         text = "Viendo",
                                         fontFamily = PoppinsBold,
-                                        fontSize = 10.sp,
+                                        fontSize = 10.asp(),
                                         color = Color.White
                                     )
                                 }
@@ -582,7 +584,7 @@ private fun AnimeCardPreview(accentColor: Color) {
                             Text(
                                 text = "18/28",
                                 fontFamily = PoppinsRegular,
-                                fontSize = 10.sp,
+                                fontSize = 10.asp(),
                                 color = Color.White.copy(alpha = 0.8f)
                             )
                         }
@@ -611,7 +613,7 @@ private fun ProgressTrackerPreview(accentColor: Color) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(300.dp),
+            .height(300.adp()),
         contentAlignment = Alignment.Center
     ) {
         // Tarjeta trasera superior - My Dress-Up Darling
@@ -687,8 +689,8 @@ private fun OnboardingAnimeCard(
 
     ElevatedCard(
         modifier = modifier
-            .width(400.dp)
-            .height(150.dp),
+            .width(400.adp())
+            .height(150.adp()),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface
         ),
@@ -699,7 +701,7 @@ private fun OnboardingAnimeCard(
             // Imagen
             Box(
                 modifier = Modifier
-                    .width(100.dp)
+                    .width(100.adp())
                     .fillMaxHeight()
             ) {
                 AsyncImage(
@@ -736,7 +738,7 @@ private fun OnboardingAnimeCard(
                         Text(
                             text = "8.5",
                             color = Color.White,
-                            fontSize = 11.sp,
+                            fontSize = 11.asp(),
                             fontFamily = PoppinsBold
                         )
                     }
@@ -755,10 +757,10 @@ private fun OnboardingAnimeCard(
                     Text(
                         text = title,
                         fontFamily = PoppinsBold,
-                        fontSize = 13.sp,
+                        fontSize = 13.asp(),
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 2,
-                        lineHeight = 16.sp
+                        lineHeight = 16.asp()
                     )
 
                     Row(
@@ -768,19 +770,19 @@ private fun OnboardingAnimeCard(
                         Text(
                             text = type,
                             fontFamily = PoppinsRegular,
-                            fontSize = 11.sp,
+                            fontSize = 11.asp(),
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                         )
                         Text(
                             text = "•",
                             fontFamily = PoppinsRegular,
-                            fontSize = 11.sp,
+                            fontSize = 11.asp(),
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
                         )
                         Text(
                             text = year,
                             fontFamily = PoppinsRegular,
-                            fontSize = 11.sp,
+                            fontSize = 11.asp(),
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                         )
                     }
@@ -799,13 +801,13 @@ private fun OnboardingAnimeCard(
                         Text(
                             text = "$episodesWatched/$totalEpisodes",
                             fontFamily = PoppinsBold,
-                            fontSize = 12.sp,
+                            fontSize = 12.asp(),
                             color = MaterialTheme.colorScheme.onSurface
                         )
                         Text(
                             text = "eps",
                             fontFamily = PoppinsRegular,
-                            fontSize = 11.sp,
+                            fontSize = 11.asp(),
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                         )
                     }
@@ -859,7 +861,7 @@ private fun OnboardingAnimeCard(
                         Text(
                             text = status,
                             fontFamily = PoppinsBold,
-                            fontSize = 10.sp,
+                            fontSize = 10.asp(),
                             color = statusColor
                         )
                     }
@@ -898,7 +900,7 @@ private fun StatsChartPreview(accentColor: Color) {
     }
 
     Column(
-        modifier = Modifier.width(300.dp),
+        modifier = Modifier.width(300.adp()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
@@ -910,15 +912,15 @@ private fun StatsChartPreview(accentColor: Color) {
             Text(
                 text = animatedValue.value.toInt().toString(),
                 fontFamily = PoppinsBold,
-                fontSize = 72.sp,
+                fontSize = 72.asp(),
                 color = accentColor,
                 letterSpacing = (-3).sp,
-                lineHeight = 72.sp
+                lineHeight = 72.asp()
             )
             Text(
                 text = "animes registrados",
                 fontFamily = PoppinsRegular,
-                fontSize = 14.sp,
+                fontSize = 14.asp(),
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
             )
         }
@@ -991,7 +993,7 @@ fun WrappedStatCard(
     modifier: Modifier = Modifier
 ) {
     Surface(
-        modifier = modifier.height(80.dp),
+        modifier = modifier.height(80.adp()),
         shape = RoundedCornerShape(16.dp),
         color = color.copy(alpha = 0.1f),
         tonalElevation = 1.dp
@@ -1007,13 +1009,13 @@ fun WrappedStatCard(
                 imageVector = icon,
                 contentDescription = null,
                 tint = color,
-                modifier = Modifier.size(16.dp)
+                modifier = Modifier.size(16.adp())
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = value,
                 fontFamily = PoppinsBold,
-                fontSize = 16.sp,
+                fontSize = 16.asp(),
                 color = color,
                 letterSpacing = (-0.5).sp,
                 maxLines = 1,
@@ -1022,7 +1024,7 @@ fun WrappedStatCard(
             Text(
                 text = label,
                 fontFamily = PoppinsRegular,
-                fontSize = 9.sp,
+                fontSize = 9.asp(),
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
             )
         }
@@ -1123,7 +1125,7 @@ private fun PodiumCard(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(40.dp)
+                            .height(40.adp())
                             .align(Alignment.BottomCenter)
                             .background(
                                 brush = Brush.verticalGradient(
@@ -1168,7 +1170,7 @@ private fun PodiumCard(
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             maxLines = 2,
-            lineHeight = 13.sp
+            lineHeight = 13.asp()
         )
     }
 }
@@ -1191,7 +1193,7 @@ private fun AndMorePreview(accentColor: Color) {
 
     Column(
         modifier = Modifier
-            .width(280.dp),
+            .width(280.adp()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -1205,7 +1207,7 @@ private fun AndMorePreview(accentColor: Color) {
                     Surface(
                         modifier = Modifier
                             .weight(1f)
-                            .height(90.dp),
+                            .height(90.adp()),
                         shape = RoundedCornerShape(18.dp),
                         color = feature.color.copy(alpha = 0.08f),
                         tonalElevation = 1.dp
@@ -1218,7 +1220,7 @@ private fun AndMorePreview(accentColor: Color) {
                             verticalArrangement = Arrangement.Center
                         ) {
                             Surface(
-                                modifier = Modifier.size(36.dp),
+                                modifier = Modifier.size(36.adp()),
                                 shape = CircleShape,
                                 color = feature.color.copy(alpha = 0.15f)
                             ) {
@@ -1230,7 +1232,7 @@ private fun AndMorePreview(accentColor: Color) {
                                         imageVector = feature.icon,
                                         contentDescription = null,
                                         tint = feature.color,
-                                        modifier = Modifier.size(20.dp)
+                                        modifier = Modifier.size(20.adp())
                                     )
                                 }
                             }
@@ -1238,7 +1240,7 @@ private fun AndMorePreview(accentColor: Color) {
                             Text(
                                 text = feature.label,
                                 fontFamily = PoppinsBold,
-                                fontSize = 11.sp,
+                                fontSize = 11.asp(),
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
                                 textAlign = TextAlign.Center
                             )
@@ -1297,20 +1299,20 @@ private fun WelcomeHeader(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(300.dp),
+            .height(300.adp()),
         contentAlignment = Alignment.Center
     ) {
         // Círculos decorativos (visibles sobre el gradiente exterior)
         Box(
             modifier = Modifier
-                .size(220.dp)
+                .size(220.adp())
                 .align(Alignment.TopEnd)
                 .offset(x = 70.dp, y = (-50).dp)
                 .background(Color.White.copy(alpha = 0.07f), CircleShape)
         )
         Box(
             modifier = Modifier
-                .size(150.dp)
+                .size(150.adp())
                 .align(Alignment.BottomStart)
                 .offset(x = (-40).dp, y = 30.dp)
                 .background(Color.White.copy(alpha = 0.06f), CircleShape)
@@ -1335,7 +1337,7 @@ private fun WelcomeHeader(
                 Box(contentAlignment = Alignment.Center) {
                     Box(
                         modifier = Modifier
-                            .size(110.dp)
+                            .size(110.adp())
                             .background(
                                 Brush.radialGradient(
                                     colors = listOf(
@@ -1350,7 +1352,7 @@ private fun WelcomeHeader(
                         painter = painterResource(id = R.drawable.logo),
                         contentDescription = "Seijaku List",
                         modifier = Modifier
-                            .size(80.dp)
+                            .size(80.adp())
                             .clip(RoundedCornerShape(20.dp))
                     )
                 }
@@ -1358,7 +1360,7 @@ private fun WelcomeHeader(
                 Text(
                     text = "Seijaku List",
                     fontFamily = PoppinsBold,
-                    fontSize = 30.sp,
+                    fontSize = 30.asp(),
                     color = Color.White,
                     textAlign = TextAlign.Center,
                     letterSpacing = (-0.5).sp
@@ -1366,7 +1368,7 @@ private fun WelcomeHeader(
                 Text(
                     text = "Tu lista de anime y mangas, siempre contigo",
                     fontFamily = PoppinsRegular,
-                    fontSize = 14.sp,
+                    fontSize = 14.asp(),
                     color = Color.White.copy(alpha = 0.82f),
                     textAlign = TextAlign.Center
                 )
@@ -1407,7 +1409,7 @@ private fun WelcomeActionsCard(
                 Text(
                     text = "¡Comienza tu aventura!",
                     fontFamily = PoppinsBold,
-                    fontSize = 22.sp,
+                    fontSize = 22.asp(),
                     color = MaterialTheme.colorScheme.onBackground,
                     textAlign = TextAlign.Center
                 )
@@ -1415,7 +1417,7 @@ private fun WelcomeActionsCard(
                 Text(
                     text = "Únete a miles de fans del anime",
                     fontFamily = PoppinsRegular,
-                    fontSize = 14.sp,
+                    fontSize = 14.asp(),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center
                 )
@@ -1426,7 +1428,7 @@ private fun WelcomeActionsCard(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(54.dp)
+                        .height(54.adp())
                         .clip(RoundedCornerShape(14.dp))
                         .background(color = MaterialTheme.colorScheme.primary)
                         .clickable(
@@ -1443,12 +1445,12 @@ private fun WelcomeActionsCard(
                             imageVector = Icons.Outlined.PersonAdd,
                             contentDescription = null,
                             tint = Color.White,
-                            modifier = Modifier.size(20.dp)
+                            modifier = Modifier.size(20.adp())
                         )
                         Text(
                             text = "Crear cuenta",
                             fontFamily = PoppinsBold,
-                            fontSize = 16.sp,
+                            fontSize = 16.asp(),
                             color = Color.White,
                             letterSpacing = 0.3.sp
                         )
@@ -1462,7 +1464,7 @@ private fun WelcomeActionsCard(
                     onClick = { navController.navigate(AppDestinations.LOGIN_ROUTE) },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(54.dp),
+                        .height(54.adp()),
                     shape = RoundedCornerShape(14.dp),
                     border = androidx.compose.foundation.BorderStroke(
                         1.5.dp,
@@ -1480,12 +1482,12 @@ private fun WelcomeActionsCard(
                             imageVector = Icons.AutoMirrored.Outlined.Login,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(20.dp)
+                            modifier = Modifier.size(20.adp())
                         )
                         Text(
                             text = "Iniciar sesión",
                             fontFamily = PoppinsBold,
-                            fontSize = 16.sp,
+                            fontSize = 16.asp(),
                             color = MaterialTheme.colorScheme.primary,
                             letterSpacing = 0.3.sp
                         )
@@ -1506,7 +1508,7 @@ private fun WelcomeActionsCard(
                     Text(
                         text = "Explorar sin cuenta",
                         fontFamily = PoppinsRegular,
-                        fontSize = 14.sp,
+                        fontSize = 14.asp(),
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     Spacer(modifier = Modifier.width(4.dp))
@@ -1514,7 +1516,7 @@ private fun WelcomeActionsCard(
                         imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(16.dp)
+                        modifier = Modifier.size(16.adp())
                     )
                 }
 
@@ -1588,7 +1590,7 @@ private fun ThemeToggleButton(
 
     Surface(
         modifier = Modifier
-            .size(48.dp)
+            .size(48.adp())
             .scale(scale),
         shape = CircleShape,
         color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.8f),
@@ -1614,7 +1616,7 @@ private fun ThemeToggleButton(
                 contentDescription = description,
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier
-                    .size(24.dp)
+                    .size(24.adp())
                     .graphicsLayer {
                         rotationZ = rotation
                     }
@@ -1649,7 +1651,7 @@ private fun ThemeChangeNotification(theme: com.yumedev.seijakulist.ui.theme.Them
                 imageVector = Icons.Outlined.Palette,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = Modifier.size(16.dp)
+                modifier = Modifier.size(16.adp())
             )
 
             Spacer(modifier = Modifier.width(8.dp))
@@ -1657,7 +1659,7 @@ private fun ThemeChangeNotification(theme: com.yumedev.seijakulist.ui.theme.Them
             Text(
                 text = "Tema cambiado a: $themeName",
                 fontFamily = PoppinsBold,
-                fontSize = 13.sp,
+                fontSize = 13.asp(),
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
                 letterSpacing = 0.2.sp
             )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/LoginScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/LoginScreen.kt
@@ -43,6 +43,8 @@ import com.yumedev.seijakulist.ui.navigation.AppDestinations
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import kotlinx.coroutines.delay
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun LoginScreen(
@@ -125,7 +127,7 @@ private fun LoginHeader(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(280.dp)
+            .height(280.adp())
             .background(
                 Brush.verticalGradient(
                     colors = listOf(
@@ -140,14 +142,14 @@ private fun LoginHeader(
         // Círculos decorativos
         Box(
             modifier = Modifier
-                .size(200.dp)
+                .size(200.adp())
                 .align(Alignment.TopEnd)
                 .offset(x = 60.dp, y = (-40).dp)
                 .background(Color.White.copy(alpha = 0.08f), CircleShape)
         )
         Box(
             modifier = Modifier
-                .size(130.dp)
+                .size(130.adp())
                 .align(Alignment.BottomStart)
                 .offset(x = (-30).dp, y = 30.dp)
                 .background(Color.White.copy(alpha = 0.06f), CircleShape)
@@ -170,7 +172,7 @@ private fun LoginHeader(
                         contentDescription = "Volver",
                         tint = Color.White,
                         modifier = Modifier
-                            .size(40.dp)
+                            .size(40.adp())
                             .padding(8.dp)
                     )
                 }
@@ -196,21 +198,21 @@ private fun LoginHeader(
                     painter = painterResource(id = R.drawable.logo),
                     contentDescription = "Seijaku List",
                     modifier = Modifier
-                        .size(72.dp)
+                        .size(72.adp())
                         .clip(RoundedCornerShape(18.dp))
                 )
                 Spacer(modifier = Modifier.height(12.dp))
                 Text(
                     text = "Bienvenido de vuelta",
                     fontFamily = PoppinsBold,
-                    fontSize = 24.sp,
+                    fontSize = 24.asp(),
                     color = Color.White,
                     textAlign = TextAlign.Center
                 )
                 Text(
                     text = "Inicia sesión en tu cuenta",
                     fontFamily = PoppinsRegular,
-                    fontSize = 14.sp,
+                    fontSize = 14.asp(),
                     color = Color.White.copy(alpha = 0.80f),
                     textAlign = TextAlign.Center
                 )
@@ -300,7 +302,7 @@ private fun LoginForm(
                         Text(
                             text = "¿Olvidaste tu contraseña?",
                             fontFamily = PoppinsRegular,
-                            fontSize = 13.sp,
+                            fontSize = 13.asp(),
                             color = MaterialTheme.colorScheme.primary
                         )
                     }
@@ -338,7 +340,7 @@ private fun LoginForm(
                     Text(
                         text = "¿No tienes cuenta? ",
                         fontFamily = PoppinsRegular,
-                        fontSize = 14.sp,
+                        fontSize = 14.asp(),
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     TextButton(
@@ -352,7 +354,7 @@ private fun LoginForm(
                         Text(
                             text = "Regístrate",
                             fontFamily = PoppinsBold,
-                            fontSize = 14.sp,
+                            fontSize = 14.asp(),
                             color = MaterialTheme.colorScheme.primary
                         )
                     }
@@ -387,7 +389,7 @@ internal fun AuthTextField(
             Text(
                 text = placeholder,
                 fontFamily = PoppinsRegular,
-                fontSize = 15.sp,
+                fontSize = 15.asp(),
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
             )
         },
@@ -397,7 +399,7 @@ internal fun AuthTextField(
                 contentDescription = null,
                 tint = if (isError) MaterialTheme.colorScheme.error
                        else MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
-                modifier = Modifier.size(22.dp)
+                modifier = Modifier.size(22.adp())
             )
         },
         trailingIcon = if (isPassword) {
@@ -427,7 +429,7 @@ internal fun AuthTextField(
         ),
         textStyle = LocalTextStyle.current.copy(
             fontFamily = PoppinsRegular,
-            fontSize = 15.sp
+            fontSize = 15.asp()
         ),
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions
@@ -455,7 +457,7 @@ internal fun AuthPrimaryButton(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(54.dp)
+            .height(54.adp())
             .scale(scale)
             .clip(RoundedCornerShape(14.dp))
             .background(
@@ -493,7 +495,7 @@ internal fun AuthPrimaryButton(
         ) {
             if (isLoading) {
                 CircularProgressIndicator(
-                    modifier = Modifier.size(22.dp),
+                    modifier = Modifier.size(22.adp()),
                     color = Color.White,
                     strokeWidth = 2.dp
                 )
@@ -501,7 +503,7 @@ internal fun AuthPrimaryButton(
                 Text(
                     text = text,
                     fontFamily = PoppinsBold,
-                    fontSize = 16.sp,
+                    fontSize = 16.asp(),
                     letterSpacing = 0.4.sp
                 )
             }
@@ -522,7 +524,7 @@ internal fun AuthSocialDivider() {
         Text(
             text = "  o continúa con  ",
             fontFamily = PoppinsRegular,
-            fontSize = 13.sp,
+            fontSize = 13.asp(),
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
         )
         HorizontalDivider(
@@ -584,7 +586,7 @@ private fun AuthSocialIconButton(
             onClick()
         },
         modifier = Modifier
-            .size(60.dp)
+            .size(60.adp())
             .scale(scale),
         shape = RoundedCornerShape(14.dp),
         colors = ButtonDefaults.outlinedButtonColors(
@@ -597,7 +599,7 @@ private fun AuthSocialIconButton(
         Image(
             painter = painterResource(id = iconRes),
             contentDescription = contentDescription,
-            modifier = Modifier.size(22.dp)
+            modifier = Modifier.size(22.adp())
         )
     }
 }
@@ -618,12 +620,12 @@ internal fun AuthErrorBanner(message: String) {
                 imageVector = Icons.Default.Error,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.error,
-                modifier = Modifier.size(18.dp)
+                modifier = Modifier.size(18.adp())
             )
             Text(
                 text = message,
                 fontFamily = PoppinsRegular,
-                fontSize = 13.sp,
+                fontSize = 13.asp(),
                 color = MaterialTheme.colorScheme.onErrorContainer,
                 modifier = Modifier.weight(1f)
             )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/RegisterScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/auth_screen/RegisterScreen.kt
@@ -34,6 +34,8 @@ import com.yumedev.seijakulist.ui.navigation.AppDestinations
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import kotlinx.coroutines.delay
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun RegisterScreen(
@@ -132,7 +134,7 @@ private fun RegisterHeader(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(260.dp)
+            .height(260.adp())
             .background(
                 Brush.verticalGradient(
                     colors = listOf(
@@ -147,14 +149,14 @@ private fun RegisterHeader(
         // Círculos decorativos
         Box(
             modifier = Modifier
-                .size(180.dp)
+                .size(180.adp())
                 .align(Alignment.TopEnd)
                 .offset(x = 50.dp, y = (-30).dp)
                 .background(Color.White.copy(alpha = 0.07f), CircleShape)
         )
         Box(
             modifier = Modifier
-                .size(120.dp)
+                .size(120.adp())
                 .align(Alignment.BottomStart)
                 .offset(x = (-20).dp, y = 20.dp)
                 .background(Color.White.copy(alpha = 0.06f), CircleShape)
@@ -177,7 +179,7 @@ private fun RegisterHeader(
                         contentDescription = "Volver",
                         tint = Color.White,
                         modifier = Modifier
-                            .size(40.dp)
+                            .size(40.adp())
                             .padding(8.dp)
                     )
                 }
@@ -200,7 +202,7 @@ private fun RegisterHeader(
                 modifier = Modifier.graphicsLayer { translationY = logoFloat }
             ) {
                 Surface(
-                    modifier = Modifier.size(72.dp),
+                    modifier = Modifier.size(72.adp()),
                     shape = RoundedCornerShape(18.dp),
                     color = Color.White.copy(alpha = 0.22f)
                 ) {
@@ -212,7 +214,7 @@ private fun RegisterHeader(
                             imageVector = Icons.Outlined.PersonAdd,
                             contentDescription = null,
                             tint = Color.White,
-                            modifier = Modifier.size(36.dp)
+                            modifier = Modifier.size(36.adp())
                         )
                     }
                 }
@@ -220,14 +222,14 @@ private fun RegisterHeader(
                 Text(
                     text = "Crear cuenta",
                     fontFamily = PoppinsBold,
-                    fontSize = 24.sp,
+                    fontSize = 24.asp(),
                     color = Color.White,
                     textAlign = TextAlign.Center
                 )
                 Text(
                     text = "¡Únete a la comunidad!",
                     fontFamily = PoppinsRegular,
-                    fontSize = 14.sp,
+                    fontSize = 14.asp(),
                     color = Color.White.copy(alpha = 0.80f),
                     textAlign = TextAlign.Center
                 )
@@ -352,7 +354,7 @@ private fun RegisterForm(
                         Text(
                             text = "Las contraseñas no coinciden",
                             fontFamily = PoppinsRegular,
-                            fontSize = 13.sp,
+                            fontSize = 13.asp(),
                             color = MaterialTheme.colorScheme.error
                         )
                     }
@@ -392,13 +394,13 @@ private fun RegisterForm(
                             Text(
                                 text = "Acepto los términos y condiciones",
                                 fontFamily = PoppinsBold,
-                                fontSize = 13.sp,
+                                fontSize = 13.asp(),
                                 color = MaterialTheme.colorScheme.onSurface
                             )
                             Text(
                                 text = "Política de privacidad de Seijaku List",
                                 fontFamily = PoppinsRegular,
-                                fontSize = 11.sp,
+                                fontSize = 11.asp(),
                                 color = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f)
                             )
                         }
@@ -437,7 +439,7 @@ private fun RegisterForm(
                     Text(
                         text = "¿Ya tienes cuenta? ",
                         fontFamily = PoppinsRegular,
-                        fontSize = 14.sp,
+                        fontSize = 14.asp(),
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     TextButton(
@@ -451,7 +453,7 @@ private fun RegisterForm(
                         Text(
                             text = "Inicia sesión",
                             fontFamily = PoppinsBold,
-                            fontSize = 14.sp,
+                            fontSize = 14.asp(),
                             color = MaterialTheme.colorScheme.primary
                         )
                     }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/characters/CharacterDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/characters/CharacterDetailScreen.kt
@@ -83,6 +83,8 @@ import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import com.yumedev.seijakulist.util.CharacterDescriptionParser
 import com.yumedev.seijakulist.util.CharacterInfo
 import kotlinx.coroutines.delay
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 // ─────────────────────────────────────────────────────────────────────────────
 //  CharacterDetailScreen
@@ -221,7 +223,7 @@ fun CharacterDetailScreen(
                         }
                     }
 
-                    item { Spacer(modifier = Modifier.height(48.dp)) }
+                    item { Spacer(modifier = Modifier.height(48.adp())) }
                 }
             }
         }
@@ -245,7 +247,7 @@ private fun CharacterHeroHeader(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(250.dp)
+            .height(250.adp())
     ) {
         Row(
             modifier = Modifier
@@ -257,7 +259,7 @@ private fun CharacterHeroHeader(
         ) {
             // Avatar circular simple
             Surface(
-                modifier        = Modifier.size(148.dp),
+                modifier        = Modifier.size(148.adp()),
                 shape           = CircleShape,
                 shadowElevation = 10.dp,
                 border          = BorderStroke(2.dp, Color.White.copy(alpha = 0.15f))
@@ -283,17 +285,17 @@ private fun CharacterHeroHeader(
             ) {
                 Text(
                     text       = character.nameCharacter,
-                    fontSize   = 24.sp,
+                    fontSize = 24.asp(),
                     fontFamily = PoppinsBold,
                     color      = Color.White,
                     textAlign  = TextAlign.Center,
-                    lineHeight = 28.sp,
+                    lineHeight = 28.asp(),
                     modifier   = Modifier.padding(horizontal = 32.dp)
                 )
                 if (character.nameKanjiCharacter.isNotEmpty() && character.nameKanjiCharacter != "N/A") {
                     Text(
                         text       = character.nameKanjiCharacter,
-                        fontSize   = 14.sp,
+                        fontSize = 14.asp(),
                         fontFamily = PoppinsRegular,
                         color      = Color.White.copy(alpha = 0.70f),
                         textAlign  = TextAlign.Center,
@@ -312,7 +314,7 @@ private fun CharacterHeroHeader(
                         Text(
                             text       = "%,d favoritos".format(character.favorites),
                             modifier   = Modifier.padding(horizontal = 14.dp, vertical = 5.dp),
-                            fontSize   = 11.sp,
+                            fontSize = 11.asp(),
                             fontFamily = PoppinsBold,
                             color      = MaterialTheme.colorScheme.primary
                         )
@@ -387,7 +389,7 @@ private fun CharacterNicknamesSection(nicknames: List<String>) {
                     Text(
                         text       = nickname,
                         modifier   = Modifier.padding(horizontal = 14.dp, vertical = 6.dp),
-                        fontSize   = 12.sp,
+                        fontSize = 12.asp(),
                         fontFamily = PoppinsMedium,
                         color      = MaterialTheme.colorScheme.onPrimaryContainer
                     )
@@ -416,8 +418,8 @@ private fun CharacterDescriptionSection(text: String, expanded: Boolean, onToggl
                     Text(
                         text       = text,
                         color      = MaterialTheme.colorScheme.onSurface,
-                        fontSize   = 14.sp,
-                        lineHeight = 22.sp,
+                        fontSize = 14.asp(),
+                        lineHeight = 22.asp(),
                         fontFamily = PoppinsRegular,
                         textAlign  = TextAlign.Justify,
                         maxLines   = if (expanded) Int.MAX_VALUE else 7,
@@ -454,7 +456,7 @@ private fun CharacterDescriptionSection(text: String, expanded: Boolean, onToggl
                         ) {
                             Text(
                                 text       = if (expanded) "Ver menos" else "Ver más",
-                                fontSize   = 12.sp,
+                                fontSize = 12.asp(),
                                 fontFamily = PoppinsBold,
                                 color      = MaterialTheme.colorScheme.primary
                             )
@@ -462,7 +464,7 @@ private fun CharacterDescriptionSection(text: String, expanded: Boolean, onToggl
                                 imageVector        = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
                                 contentDescription = null,
                                 tint               = MaterialTheme.colorScheme.primary,
-                                modifier           = Modifier.size(16.dp)
+                                modifier           = Modifier.size(16.adp())
                             )
                         }
                     }
@@ -549,7 +551,7 @@ private fun CharacterGallerySection(
                 Text(
                     text     = "${pictures.size}",
                     modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-                    fontSize = 12.sp,
+                    fontSize = 12.asp(),
                     fontFamily = PoppinsBold,
                     color    = MaterialTheme.colorScheme.primary
                 )
@@ -563,8 +565,8 @@ private fun CharacterGallerySection(
             items(pictures) { picture ->
                 ElevatedCard(
                     modifier  = Modifier
-                        .width(140.dp)
-                        .height(210.dp)
+                        .width(140.adp())
+                        .height(210.adp())
                         .clickable { onImageClick(picture.characterPictures) },
                     shape     = RoundedCornerShape(14.dp),
                     elevation = CardDefaults.cardElevation(defaultElevation = 3.dp)
@@ -591,13 +593,13 @@ private fun CharacterGallerySection(
 @Composable
 private fun VoiceActorCard(voiceActor: VoiceActorDomain) {
     Column(
-        modifier              = Modifier.width(82.dp),
+        modifier              = Modifier.width(82.adp()),
         horizontalAlignment   = Alignment.CenterHorizontally,
         verticalArrangement   = Arrangement.spacedBy(6.dp)
     ) {
         // Foto circular
         Surface(
-            modifier        = Modifier.size(72.dp),
+            modifier        = Modifier.size(72.adp()),
             shape           = CircleShape,
             color           = MaterialTheme.colorScheme.surfaceContainerHigh,
             shadowElevation = 2.dp
@@ -614,13 +616,13 @@ private fun VoiceActorCard(voiceActor: VoiceActorDomain) {
         }
         Text(
             text       = voiceActor.name,
-            fontSize   = 10.sp,
+            fontSize = 10.asp(),
             fontFamily = PoppinsBold,
             color      = MaterialTheme.colorScheme.onSurface,
             textAlign  = TextAlign.Center,
             maxLines   = 2,
             overflow   = TextOverflow.Ellipsis,
-            lineHeight = 13.sp
+            lineHeight = 13.asp()
         )
         if (voiceActor.language.isNotEmpty()) {
             Surface(
@@ -630,7 +632,7 @@ private fun VoiceActorCard(voiceActor: VoiceActorDomain) {
                 Text(
                     text       = voiceActor.language,
                     modifier   = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-                    fontSize   = 9.sp,
+                    fontSize = 9.asp(),
                     fontFamily = PoppinsMedium,
                     color      = MaterialTheme.colorScheme.onSecondaryContainer,
                     maxLines   = 1,
@@ -648,7 +650,7 @@ private fun VoiceActorCard(voiceActor: VoiceActorDomain) {
 private fun CharacterAppearanceCard(item: AppearanceItem, navController: NavController) {
     ElevatedCard(
         modifier  = Modifier
-            .width(110.dp)
+            .width(110.adp())
             .clickable(enabled = item.malId > 0) {
                 navController.navigate("${AppDestinations.ANIME_DETAIL_ROUTE}/${item.malId}")
             },
@@ -657,7 +659,7 @@ private fun CharacterAppearanceCard(item: AppearanceItem, navController: NavCont
     ) {
         Box(modifier = Modifier
             .fillMaxWidth()
-            .height(155.dp)
+            .height(155.adp())
         ) {
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
@@ -684,7 +686,7 @@ private fun CharacterAppearanceCard(item: AppearanceItem, navController: NavCont
                     Text(
                         text       = item.tag,
                         modifier   = Modifier.padding(horizontal = 5.dp, vertical = 2.dp),
-                        fontSize   = 8.sp,
+                        fontSize = 8.asp(),
                         fontFamily = PoppinsBold,
                         color      = Color.White,
                         maxLines   = 1
@@ -694,12 +696,12 @@ private fun CharacterAppearanceCard(item: AppearanceItem, navController: NavCont
             // Título (bottom)
             Text(
                 text       = item.title,
-                fontSize   = 10.sp,
+                fontSize = 10.asp(),
                 fontFamily = PoppinsBold,
                 color      = Color.White,
                 maxLines   = 2,
                 overflow   = TextOverflow.Ellipsis,
-                lineHeight = 13.sp,
+                lineHeight = 13.asp(),
                 modifier   = Modifier
                     .align(Alignment.BottomStart)
                     .fillMaxWidth()
@@ -726,19 +728,19 @@ private fun CharacterInfoChip(info: CharacterInfo) {
         ) {
             Text(
                 text       = info.key,
-                fontSize   = 11.sp,
+                fontSize = 11.asp(),
                 fontFamily = PoppinsRegular,
                 color      = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.75f),
                 maxLines   = 1
             )
             Text(
                 text     = "·",
-                fontSize = 12.sp,
+                fontSize = 12.asp(),
                 color    = MaterialTheme.colorScheme.outlineVariant
             )
             Text(
                 text       = info.value,
-                fontSize   = 11.sp,
+                fontSize = 11.asp(),
                 fontFamily = PoppinsBold,
                 color      = MaterialTheme.colorScheme.onSurface,
                 maxLines   = 1,
@@ -804,13 +806,13 @@ private fun CharacterLoadingState() {
             verticalArrangement   = Arrangement.spacedBy(16.dp)
         ) {
             CircularProgressIndicator(
-                modifier  = Modifier.size(48.dp),
+                modifier  = Modifier.size(48.adp()),
                 color     = MaterialTheme.colorScheme.primary,
                 strokeWidth = 3.dp
             )
             Text(
                 text       = "Cargando personaje...",
-                fontSize   = 14.sp,
+                fontSize = 14.asp(),
                 fontFamily = PoppinsRegular,
                 color      = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -828,17 +830,17 @@ private fun CharacterErrorState(message: String) {
         ) {
             Text(
                 text       = "Algo salió mal",
-                fontSize   = 20.sp,
+                fontSize = 20.asp(),
                 fontFamily = PoppinsBold,
                 color      = MaterialTheme.colorScheme.onSurface
             )
             Text(
                 text       = message,
-                fontSize   = 13.sp,
+                fontSize = 13.asp(),
                 fontFamily = PoppinsRegular,
                 color      = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign  = TextAlign.Center,
-                lineHeight = 18.sp
+                lineHeight = 18.asp()
             )
         }
     }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/configuration/ConfigurationScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/configuration/ConfigurationScreen.kt
@@ -60,6 +60,8 @@ import com.yumedev.seijakulist.ui.theme.ThemeMode
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.yumedev.seijakulist.ui.components.confirm_dialog.ConfirmSignOutDialog
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @RequiresApi(Build.VERSION_CODES.P)
 @OptIn(ExperimentalMaterial3Api::class)
@@ -110,7 +112,7 @@ fun ConfigurationScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp)
+                .height(56.adp())
                 .background(MaterialTheme.colorScheme.background)
         ) {
             IconButton(
@@ -126,7 +128,7 @@ fun ConfigurationScreen(
             Text(
                 text = "Configuración",
                 color = MaterialTheme.colorScheme.onSurface,
-                fontSize = 20.sp,
+                fontSize = 20.asp(),
                 fontFamily = PoppinsBold,
                 modifier = Modifier.align(Alignment.Center)
             )
@@ -336,7 +338,7 @@ fun ConfigurationScreen(
 private fun SectionTitle(text: String) {
     Text(
         text = text,
-        fontSize = 14.sp,
+        fontSize = 14.asp(),
         fontWeight = FontWeight.SemiBold,
         fontFamily = PoppinsBold,
         color = MaterialTheme.colorScheme.primary,
@@ -368,7 +370,7 @@ private fun SettingItem(
         // Ícono
         Box(
             modifier = Modifier
-                .size(40.dp)
+                .size(40.adp())
                 .background(
                     MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
                     RoundedCornerShape(10.dp)
@@ -379,7 +381,7 @@ private fun SettingItem(
                 imageVector = icon,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(24.adp())
             )
         }
 
@@ -391,7 +393,7 @@ private fun SettingItem(
         ) {
             Text(
                 text = title,
-                fontSize = 16.sp,
+                fontSize = 16.asp(),
                 fontWeight = FontWeight.Medium,
                 fontFamily = PoppinsBold,
                 color = MaterialTheme.colorScheme.onSurface
@@ -400,7 +402,7 @@ private fun SettingItem(
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = subtitle,
-                    fontSize = 13.sp,
+                    fontSize = 13.asp(),
                     fontFamily = PoppinsRegular,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )
@@ -414,7 +416,7 @@ private fun SettingItem(
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
                 modifier = Modifier
-                    .size(20.dp)
+                    .size(20.adp())
             )
         }
     }
@@ -438,7 +440,7 @@ private fun SettingItemWithSwitch(
         // Ícono
         Box(
             modifier = Modifier
-                .size(40.dp)
+                .size(40.adp())
                 .background(
                     MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
                     RoundedCornerShape(10.dp)
@@ -449,7 +451,7 @@ private fun SettingItemWithSwitch(
                 imageVector = icon,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(24.adp())
             )
         }
 
@@ -461,7 +463,7 @@ private fun SettingItemWithSwitch(
         ) {
             Text(
                 text = title,
-                fontSize = 16.sp,
+                fontSize = 16.asp(),
                 fontWeight = FontWeight.Medium,
                 fontFamily = PoppinsBold,
                 color = MaterialTheme.colorScheme.onSurface
@@ -470,7 +472,7 @@ private fun SettingItemWithSwitch(
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = subtitle,
-                    fontSize = 13.sp,
+                    fontSize = 13.asp(),
                     fontFamily = PoppinsRegular,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )
@@ -523,7 +525,7 @@ private fun ThemeOption(
         ) {
             Text(
                 text = title,
-                fontSize = 16.sp,
+                fontSize = 16.asp(),
                 fontWeight = FontWeight.Medium,
                 fontFamily = PoppinsBold,
                 color = MaterialTheme.colorScheme.onSurface
@@ -532,7 +534,7 @@ private fun ThemeOption(
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = subtitle,
-                    fontSize = 13.sp,
+                    fontSize = 13.asp(),
                     fontFamily = PoppinsRegular,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/AnimeDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/AnimeDetailScreen.kt
@@ -203,6 +203,8 @@ import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.TextStyle
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -414,7 +416,7 @@ fun AnimeDetailScreen(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(56.dp)
+                        .height(56.adp())
                         .background(MaterialTheme.colorScheme.background)
                 ) {
                     IconButton(
@@ -430,7 +432,7 @@ fun AnimeDetailScreen(
                     Text(
                         text = "Detalle del anime",
                         color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 18.sp,
+                        fontSize = 18.asp(),
                         fontFamily = PoppinsBold,
                         modifier = Modifier.align(Alignment.Center)
                     )
@@ -529,7 +531,7 @@ fun AnimeDetailScreen(
                                     Surface(
                                         shape = CircleShape,
                                         color = Color(0xFF4CAF50),
-                                        modifier = Modifier.size(40.dp)
+                                        modifier = Modifier.size(40.adp())
                                     ) {
                                         Box(
                                             contentAlignment = Alignment.Center,
@@ -539,7 +541,7 @@ fun AnimeDetailScreen(
                                                 imageVector = Icons.Default.CheckCircle,
                                                 contentDescription = null,
                                                 tint = Color.White,
-                                                modifier = Modifier.size(24.dp)
+                                                modifier = Modifier.size(24.adp())
                                             )
                                         }
                                     }
@@ -592,7 +594,7 @@ fun AnimeDetailScreen(
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(340.dp)
+                                    .height(340.adp())
                             ) {
                                 // 1. FONDO DIFUMINADO (Mantenemos el efecto premium)
                                 AsyncImage(
@@ -633,8 +635,8 @@ fun AnimeDetailScreen(
                                     // PORTADA
                                     Card(
                                         modifier = Modifier
-                                            .width(140.dp)
-                                            .height(210.dp),
+                                            .width(140.adp())
+                                            .height(210.adp()),
                                         shape = RoundedCornerShape(12.dp),
                                         elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
                                     ) {
@@ -654,7 +656,7 @@ fun AnimeDetailScreen(
                                     Column(
                                         modifier = Modifier
                                             .weight(1f)
-                                            .height(210.dp), // Misma altura que la portada
+                                            .height(210.adp()), // Misma altura que la portada
                                         verticalArrangement = Arrangement.SpaceBetween // Empuja los datos arriba y el botón abajo
                                     ) {
                                         // SECCIÓN SUPERIOR: Títulos y Status
@@ -662,18 +664,18 @@ fun AnimeDetailScreen(
                                             Text(
                                                 text = animeDetail?.title ?: "",
                                                 color = MaterialTheme.colorScheme.onSurface,
-                                                fontSize = 18.sp,
+                                                fontSize = 18.asp(),
                                                 fontFamily = PoppinsBold,
                                                 maxLines = 2,
                                                 overflow = TextOverflow.Ellipsis,
-                                                lineHeight = 22.sp
+                                                lineHeight = 22.asp()
                                             )
 
                                             if (!animeDetail?.titleJapanese.isNullOrBlank()) {
                                                 Text(
                                                     text = animeDetail?.titleJapanese ?: "",
                                                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                                                    fontSize = 11.sp,
+                                                    fontSize = 11.asp(),
                                                     fontFamily = PoppinsRegular,
                                                     maxLines = 1
                                                 )
@@ -704,7 +706,7 @@ fun AnimeDetailScreen(
                                                 onClick = { showAddToListSheet = true },
                                                 modifier = Modifier
                                                     .fillMaxWidth()
-                                                    .height(42.dp), // Altura reducida
+                                                    .height(42.adp()), // Altura reducida
                                                 shape = RoundedCornerShape(10.dp),
                                                 contentPadding = PaddingValues(horizontal = 12.dp),
                                                 colors = ButtonDefaults.buttonColors(
@@ -717,12 +719,12 @@ fun AnimeDetailScreen(
                                                 Icon(
                                                     imageVector = if (isAdded) Icons.Default.Edit else Icons.Default.Favorite,
                                                     contentDescription = null,
-                                                    modifier = Modifier.size(16.dp)
+                                                    modifier = Modifier.size(16.adp())
                                                 )
                                                 Spacer(modifier = Modifier.width(8.dp))
                                                 Text(
                                                     text = if (isAdded) "Editar lista" else "Añadir",
-                                                    fontSize = 13.sp,
+                                                    fontSize = 13.asp(),
                                                     fontFamily = PoppinsBold
                                                 )
                                             }
@@ -768,7 +770,7 @@ fun AnimeDetailScreen(
                                                 Icon(
                                                     imageVector = icon,
                                                     contentDescription = null,
-                                                    modifier = Modifier.size(24.dp),
+                                                    modifier = Modifier.size(24.adp()),
                                                     tint = iconColor
                                                 )
                                             }
@@ -800,7 +802,7 @@ fun AnimeDetailScreen(
                                         ) {
                                             Text(
                                                 text = "Géneros",
-                                                fontSize = 16.sp,
+                                                fontSize = 16.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = MaterialTheme.colorScheme.onSurface
                                             )
@@ -823,7 +825,7 @@ fun AnimeDetailScreen(
                                                             text = genre.name ?: "N/A",
                                                             color = MaterialTheme.colorScheme.onPrimaryContainer,
                                                             fontFamily = PoppinsRegular,
-                                                            fontSize = 13.sp,
+                                                            fontSize = 13.asp(),
                                                             modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
                                                         )
                                                     }
@@ -855,7 +857,7 @@ fun AnimeDetailScreen(
                                     ) {
                                         Text(
                                             text = "Sinopsis",
-                                            fontSize = 16.sp,
+                                            fontSize = 16.asp(),
                                             fontFamily = PoppinsBold,
                                             color = MaterialTheme.colorScheme.onSurface
                                         )
@@ -867,10 +869,10 @@ fun AnimeDetailScreen(
                                         Text(
                                             text = animeDetail?.synopsis ?: "Sinopsis no encontrada",
                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                            fontSize = 14.sp,
+                                            fontSize = 14.asp(),
                                             fontFamily = PoppinsRegular,
                                             textAlign = TextAlign.Justify,
-                                            lineHeight = 20.sp,
+                                            lineHeight = 20.asp(),
                                             maxLines = if (expanded) Int.MAX_VALUE else 8,
                                             onTextLayout = { textLayoutResult = it }
                                         )
@@ -879,7 +881,7 @@ fun AnimeDetailScreen(
                                             Text(
                                                 text = if (expanded) "Ver menos" else "Ver más",
                                                 fontFamily = PoppinsBold,
-                                                fontSize = 13.sp,
+                                                fontSize = 13.asp(),
                                                 color = MaterialTheme.colorScheme.primary,
                                                 modifier = Modifier.clickable { expanded = !expanded }
                                             )
@@ -910,7 +912,7 @@ fun AnimeDetailScreen(
                                         ) {
                                             Text(
                                                 text = "Otros títulos",
-                                                fontSize = 16.sp,
+                                                fontSize = 16.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = MaterialTheme.colorScheme.onSurface
                                             )
@@ -919,13 +921,13 @@ fun AnimeDetailScreen(
                                                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                                     Text(
                                                         text = "Inglés",
-                                                        fontSize = 12.sp,
+                                                        fontSize = 12.asp(),
                                                         fontFamily = PoppinsRegular,
                                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                                     )
                                                     Text(
                                                         text = animeDetail?.titleEnglish ?: "",
-                                                        fontSize = 14.sp,
+                                                        fontSize = 14.asp(),
                                                         fontFamily = PoppinsBold,
                                                         color = MaterialTheme.colorScheme.onSurface
                                                     )
@@ -941,13 +943,13 @@ fun AnimeDetailScreen(
                                                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                                     Text(
                                                         text = "Japonés",
-                                                        fontSize = 12.sp,
+                                                        fontSize = 12.asp(),
                                                         fontFamily = PoppinsRegular,
                                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                                     )
                                                     Text(
                                                         text = animeDetail?.titleJapanese ?: "",
-                                                        fontSize = 14.sp,
+                                                        fontSize = 14.asp(),
                                                         fontFamily = PoppinsBold,
                                                         color = MaterialTheme.colorScheme.onSurface
                                                     )
@@ -980,7 +982,7 @@ fun AnimeDetailScreen(
                                         ) {
                                             Text(
                                                 text = "Estudio",
-                                                fontSize = 16.sp,
+                                                fontSize = 16.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = MaterialTheme.colorScheme.onSurface
                                             )
@@ -1004,7 +1006,7 @@ fun AnimeDetailScreen(
                                                             text = studio.nameStudio ?: "N/A",
                                                             color = MaterialTheme.colorScheme.onSecondaryContainer,
                                                             fontFamily = PoppinsRegular,
-                                                            fontSize = 13.sp,
+                                                            fontSize = 13.asp(),
                                                             modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
                                                         )
                                                     }
@@ -1036,7 +1038,7 @@ fun AnimeDetailScreen(
                                     ) {
                                         Text(
                                             text = "Información",
-                                            fontSize = 16.sp,
+                                            fontSize = 16.asp(),
                                             fontFamily = PoppinsBold,
                                             color = MaterialTheme.colorScheme.onSurface,
                                             modifier = Modifier.padding(bottom = 4.dp)
@@ -1103,7 +1105,7 @@ fun AnimeDetailScreen(
                                     ) {
                                         Text(
                                             text = "Temas Musicales",
-                                            fontSize = 16.sp,
+                                            fontSize = 16.asp(),
                                             fontFamily = PoppinsBold,
                                             color = MaterialTheme.colorScheme.onSurface
                                         )
@@ -1132,10 +1134,10 @@ fun AnimeDetailScreen(
                                     Box(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .height(220.dp),
+                                            .height(220.adp()),
                                         contentAlignment = Alignment.Center
                                     ) {
-                                        CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                                        CircularProgressIndicator(modifier = Modifier.size(32.adp()))
                                     }
                                 } else if (recommendations.isNotEmpty()) {
                                     Spacer(modifier = Modifier.height(8.dp))
@@ -1152,7 +1154,7 @@ fun AnimeDetailScreen(
                                                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                                                 color = MaterialTheme.colorScheme.primary,
                                                 fontFamily = PoppinsBold,
-                                                fontSize = 13.sp
+                                                fontSize = 13.asp()
                                             )
                                         }
                                     }
@@ -1195,7 +1197,7 @@ fun AnimeDetailScreen(
                                                         "Buscar por nombre...",
                                                         style = TextStyle(
                                                             fontFamily = PoppinsRegular,
-                                                            fontSize = 15.sp,
+                                                            fontSize = 15.asp(),
                                                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
                                                         )
                                                     )
@@ -1205,7 +1207,7 @@ fun AnimeDetailScreen(
                                                         Icons.Rounded.Search,
                                                         null,
                                                         tint = MaterialTheme.colorScheme.primary,
-                                                        modifier = Modifier.size(22.dp)
+                                                        modifier = Modifier.size(22.adp())
                                                     )
                                                 },
                                                 trailingIcon = {
@@ -1217,7 +1219,7 @@ fun AnimeDetailScreen(
                                                             Icons.Rounded.Close,
                                                             null,
                                                             tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                                                            modifier = Modifier.size(20.dp)
+                                                            modifier = Modifier.size(20.adp())
                                                         )
                                                     }
                                                 },
@@ -1231,7 +1233,7 @@ fun AnimeDetailScreen(
                                                 ),
                                                 textStyle = TextStyle(
                                                     fontFamily = PoppinsMedium,
-                                                    fontSize = 15.sp,
+                                                    fontSize = 15.asp(),
                                                     color = MaterialTheme.colorScheme.onSurface
                                                 )
                                             )
@@ -1243,13 +1245,13 @@ fun AnimeDetailScreen(
                                         ) {
                                             IconButton(
                                                 onClick = { isSearching = true },
-                                                modifier = Modifier.size(44.dp)
+                                                modifier = Modifier.size(44.adp())
                                             ) {
                                                 Icon(
                                                     imageVector = Icons.Rounded.Search,
                                                     contentDescription = "Buscar",
                                                     tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                                                    modifier = Modifier.size(26.dp)
+                                                    modifier = Modifier.size(26.adp())
                                                 )
                                             }
                                         }
@@ -1370,7 +1372,7 @@ fun AnimeDetailScreen(
                                                                             Box(
                                                                                 modifier = Modifier
                                                                                     .fillMaxWidth()
-                                                                                    .height(160.dp)
+                                                                                    .height(160.adp())
                                                                             ) {
                                                                                 AsyncImage(
                                                                                     model = ImageRequest.Builder(
@@ -1411,7 +1413,7 @@ fun AnimeDetailScreen(
                                                                                             "Main" -> MaterialTheme.colorScheme.onPrimaryContainer
                                                                                             else -> MaterialTheme.colorScheme.onSecondaryContainer
                                                                                         },
-                                                                                        fontSize = 10.sp
+                                                                                        fontSize = 10.asp()
                                                                                     )
                                                                                 }
                                                                             }
@@ -1429,8 +1431,8 @@ fun AnimeDetailScreen(
                                                                                     vertical = 12.dp
                                                                                 ),
                                                                                 color = MaterialTheme.colorScheme.onSurface,
-                                                                                fontSize = 13.sp,
-                                                                                lineHeight = 16.sp
+                                                                                fontSize = 13.asp(),
+                                                                                lineHeight = 16.asp()
                                                                             )
                                                                         }
                                                                     }
@@ -1470,7 +1472,7 @@ fun AnimeDetailScreen(
                                                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                                                 color = MaterialTheme.colorScheme.primary,
                                                 fontFamily = PoppinsBold,
-                                                fontSize = 13.sp
+                                                fontSize = 13.asp()
                                             )
                                         }
                                     }
@@ -1493,7 +1495,7 @@ fun AnimeDetailScreen(
                                     ) {
                                         Icon(
                                             Icons.Default.PhotoLibrary, null,
-                                            Modifier.size(40.dp),
+                                            Modifier.size(40.adp()),
                                             tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
                                         )
                                         Text("Sin imágenes disponibles", fontFamily = PoppinsMedium,
@@ -1553,7 +1555,7 @@ fun AnimeDetailScreen(
                                                 modifier = Modifier.fillMaxWidth(),
                                                 shape = RoundedCornerShape(12.dp)
                                             ) {
-                                                Icon(Icons.Default.ExpandMore, null, Modifier.size(18.dp))
+                                                Icon(Icons.Default.ExpandMore, null, Modifier.size(18.adp()))
                                                 Spacer(Modifier.width(6.dp))
                                                 Text("Ver ${animePictures.size - 9} fotos más", fontFamily = PoppinsMedium)
                                             }
@@ -1572,7 +1574,7 @@ fun AnimeDetailScreen(
                                     Box(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .height(100.dp),
+                                            .height(100.adp()),
                                         contentAlignment = Alignment.Center
                                     ) {
                                         CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
@@ -1595,28 +1597,28 @@ fun AnimeDetailScreen(
                                                 Icons.Default.PlayCircle,
                                                 contentDescription = null,
                                                 tint = MaterialTheme.colorScheme.primary,
-                                                modifier = Modifier.size(24.dp)
+                                                modifier = Modifier.size(24.adp())
                                             )
                                             Spacer(modifier = Modifier.width(12.dp))
                                             Text(
                                                 text = "Trailers",
                                                 color = MaterialTheme.colorScheme.onSurface,
                                                 fontFamily = PoppinsBold,
-                                                fontSize = 20.sp
+                                                fontSize = 20.asp()
                                             )
                                             Spacer(modifier = Modifier.weight(1f))
                                             Text(
                                                 text = "${validPromos.size} video${if (validPromos.size != 1) "s" else ""}",
                                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                                                 fontFamily = PoppinsRegular,
-                                                fontSize = 13.sp
+                                                fontSize = 13.asp()
                                             )
                                         }
                                         Spacer(modifier = Modifier.height(12.dp))
                                         Text(
                                             text = "Trailers y promos oficiales",
                                             fontFamily = PoppinsRegular,
-                                            fontSize = 12.sp,
+                                            fontSize = 12.asp(),
                                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
                                             modifier = Modifier.padding(start = 52.dp)
                                         )
@@ -1657,28 +1659,28 @@ fun AnimeDetailScreen(
                                                 Icons.Default.MusicNote,
                                                 contentDescription = null,
                                                 tint = MaterialTheme.colorScheme.primary,
-                                                modifier = Modifier.size(24.dp)
+                                                modifier = Modifier.size(24.adp())
                                             )
                                             Spacer(modifier = Modifier.width(12.dp))
                                             Text(
                                                 text = "Music Videos",
                                                 color = MaterialTheme.colorScheme.onSurface,
                                                 fontFamily = PoppinsBold,
-                                                fontSize = 20.sp
+                                                fontSize = 20.asp()
                                             )
                                             Spacer(modifier = Modifier.weight(1f))
                                             Text(
                                                 text = "${validMusicVideos.size} video${if (validMusicVideos.size != 1) "s" else ""}",
                                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                                                 fontFamily = PoppinsRegular,
-                                                fontSize = 13.sp
+                                                fontSize = 13.asp()
                                             )
                                         }
                                         Spacer(modifier = Modifier.height(12.dp))
                                         Text(
                                             text = "Abre en YouTube",
                                             fontFamily = PoppinsRegular,
-                                            fontSize = 12.sp,
+                                            fontSize = 12.asp(),
                                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
                                             modifier = Modifier.padding(start = 52.dp)
                                         )
@@ -1722,7 +1724,7 @@ fun AnimeDetailScreen(
                                                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                                                 color = MaterialTheme.colorScheme.primary,
                                                 fontFamily = PoppinsBold,
-                                                fontSize = 13.sp
+                                                fontSize = 13.asp()
                                             )
                                         }
                                     }
@@ -1735,13 +1737,13 @@ fun AnimeDetailScreen(
                                     Box(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .height(100.dp),
+                                            .height(100.adp()),
                                         contentAlignment = Alignment.Center
                                     ) {
                                         CircularProgressIndicator(
                                             color = MaterialTheme.colorScheme.primary,
                                             strokeWidth = 2.dp,
-                                            modifier = Modifier.size(28.dp)
+                                            modifier = Modifier.size(28.adp())
                                         )
                                     }
                                 }
@@ -1754,7 +1756,7 @@ fun AnimeDetailScreen(
                                     ) {
                                         Icon(
                                             Icons.Default.OndemandVideo, null,
-                                            Modifier.size(40.dp),
+                                            Modifier.size(40.adp()),
                                             tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
                                         )
                                         Text("Sin episodios disponibles", fontFamily = PoppinsMedium,
@@ -1782,8 +1784,8 @@ fun AnimeDetailScreen(
 
                                                 Card(
                                                     modifier = Modifier
-                                                        .width(170.dp)
-                                                        .height(130.dp)
+                                                        .width(170.adp())
+                                                        .height(130.adp())
                                                         .clickable {
                                                             animeDetail?.let { anime ->
                                                                 animeDetailViewModel.loadEpisodeDetail(anime.malId, episode.malId!!)
@@ -1812,7 +1814,7 @@ fun AnimeDetailScreen(
                                                             ) {
                                                                 Icon(
                                                                     Icons.Default.OndemandVideo, null,
-                                                                    Modifier.size(32.dp),
+                                                                    Modifier.size(32.adp()),
                                                                     tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f)
                                                                 )
                                                             }
@@ -1821,7 +1823,7 @@ fun AnimeDetailScreen(
                                                         Box(
                                                             Modifier
                                                                 .fillMaxWidth()
-                                                                .height(90.dp)
+                                                                .height(90.adp())
                                                                 .align(Alignment.BottomCenter)
                                                                 .background(
                                                                     Brush.verticalGradient(
@@ -1850,7 +1852,7 @@ fun AnimeDetailScreen(
                                                                 Text(
                                                                     text = "Ep ${episode.malId ?: "?"}",
                                                                     color = MaterialTheme.colorScheme.onPrimary,
-                                                                    fontSize = 9.sp,
+                                                                    fontSize = 9.asp(),
                                                                     fontFamily = PoppinsBold
                                                                 )
                                                             }
@@ -1866,7 +1868,7 @@ fun AnimeDetailScreen(
                                                                     Text(
                                                                         "Filler",
                                                                         color = Color.White,
-                                                                        fontSize = 9.sp,
+                                                                        fontSize = 9.asp(),
                                                                         fontFamily = PoppinsBold
                                                                     )
                                                                 }
@@ -1882,7 +1884,7 @@ fun AnimeDetailScreen(
                                                                     Text(
                                                                         "Recap",
                                                                         color = Color.White,
-                                                                        fontSize = 9.sp,
+                                                                        fontSize = 9.asp(),
                                                                         fontFamily = PoppinsBold
                                                                     )
                                                                 }
@@ -1899,11 +1901,11 @@ fun AnimeDetailScreen(
                                                             Text(
                                                                 text = episode.title ?: "Episodio ${episode.malId}",
                                                                 color = Color.White,
-                                                                fontSize = 11.sp,
+                                                                fontSize = 11.asp(),
                                                                 fontFamily = PoppinsBold,
                                                                 maxLines = 2,
                                                                 overflow = TextOverflow.Ellipsis,
-                                                                lineHeight = 15.sp
+                                                                lineHeight = 15.asp()
                                                             )
                                                             if (episode.score != null && episode.score > 0) {
                                                                 Row(
@@ -1918,7 +1920,7 @@ fun AnimeDetailScreen(
                                                                     Text(
                                                                         text = String.format("%.1f", episode.score),
                                                                         color = Color.White.copy(alpha = 0.8f),
-                                                                        fontSize = 10.sp,
+                                                                        fontSize = 10.asp(),
                                                                         fontFamily = PoppinsMedium
                                                                     )
                                                                 }
@@ -1956,7 +1958,7 @@ fun AnimeDetailScreen(
                                                 CircularProgressIndicator(
                                                     color = MaterialTheme.colorScheme.primary,
                                                     strokeWidth = 2.dp,
-                                                    modifier = Modifier.size(28.dp)
+                                                    modifier = Modifier.size(28.adp())
                                                 )
                                             } else {
                                                 OutlinedButton(
@@ -1969,7 +1971,7 @@ fun AnimeDetailScreen(
                                                     Icon(
                                                         Icons.Default.ExpandMore,
                                                         contentDescription = null,
-                                                        modifier = Modifier.size(20.dp)
+                                                        modifier = Modifier.size(20.adp())
                                                     )
                                                     Spacer(modifier = Modifier.width(8.dp))
                                                     Text(
@@ -2000,7 +2002,7 @@ fun AnimeDetailScreen(
                                                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                                                 color = MaterialTheme.colorScheme.primary,
                                                 fontFamily = PoppinsBold,
-                                                fontSize = 13.sp
+                                                fontSize = 13.asp()
                                             )
                                         }
                                     }
@@ -2090,8 +2092,8 @@ fun AnimeDetailScreen(
                                                     maxLines = 2,
                                                     overflow = TextOverflow.Ellipsis,
                                                     fontFamily = PoppinsBold,
-                                                    fontSize = 15.sp,
-                                                    lineHeight = 20.sp,
+                                                    fontSize = 15.asp(),
+                                                    lineHeight = 20.asp(),
                                                     color = MaterialTheme.colorScheme.onSurface
                                                 )
 
@@ -2113,13 +2115,13 @@ fun AnimeDetailScreen(
                                                             color = MaterialTheme.colorScheme.primaryContainer.copy(
                                                                 alpha = 0.4f
                                                             ),
-                                                            modifier = Modifier.size(24.dp)
+                                                            modifier = Modifier.size(24.adp())
                                                         ) {
                                                             Box(contentAlignment = Alignment.Center) {
                                                                 Text(
                                                                     text = topic.authorUsername.firstOrNull()
                                                                         ?.uppercase() ?: "?",
-                                                                    fontSize = 11.sp,
+                                                                    fontSize = 11.asp(),
                                                                     fontFamily = PoppinsBold,
                                                                     color = MaterialTheme.colorScheme.primary
                                                                 )
@@ -2129,7 +2131,7 @@ fun AnimeDetailScreen(
                                                         Text(
                                                             text = topic.authorUsername,
                                                             fontFamily = PoppinsMedium,
-                                                            fontSize = 12.sp,
+                                                            fontSize = 12.asp(),
                                                             color = MaterialTheme.colorScheme.onSurfaceVariant
                                                         )
                                                     }
@@ -2160,7 +2162,7 @@ fun AnimeDetailScreen(
                                                             Text(
                                                                 text = "${topic.comments}",
                                                                 fontFamily = PoppinsBold,
-                                                                fontSize = 11.sp,
+                                                                fontSize = 11.asp(),
                                                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                                                             )
                                                         }
@@ -2205,7 +2207,7 @@ fun AnimeDetailScreen(
                                             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                                             color = MaterialTheme.colorScheme.primary,
                                             fontFamily = PoppinsBold,
-                                            fontSize = 13.sp
+                                            fontSize = 13.asp()
                                         )
                                     }
                                 }
@@ -2247,7 +2249,7 @@ fun AnimeDetailScreen(
                                         Box(
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .height(120.dp),
+                                                .height(120.adp()),
                                             contentAlignment = Alignment.Center
                                         ) {
                                             Column(
@@ -2257,13 +2259,13 @@ fun AnimeDetailScreen(
                                                 CircularProgressIndicator(
                                                     color = MaterialTheme.colorScheme.primary,
                                                     strokeWidth = 2.dp,
-                                                    modifier = Modifier.size(28.dp)
+                                                    modifier = Modifier.size(28.adp())
                                                 )
                                                 Text(
                                                     text = "Cargando estudio...",
                                                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                                                     fontFamily = PoppinsRegular,
-                                                    fontSize = 13.sp
+                                                    fontSize = 13.asp()
                                                 )
                                             }
                                         }
@@ -2285,13 +2287,13 @@ fun AnimeDetailScreen(
                                                     Icons.Default.Close,
                                                     contentDescription = null,
                                                     tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
-                                                    modifier = Modifier.size(20.dp)
+                                                    modifier = Modifier.size(20.adp())
                                                 )
                                                 Text(
                                                     text = "No se pudo cargar la información del estudio",
                                                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                                                     fontFamily = PoppinsRegular,
-                                                    fontSize = 13.sp
+                                                    fontSize = 13.asp()
                                                 )
                                             }
                                         }
@@ -2328,7 +2330,7 @@ fun AnimeDetailScreen(
                                                     ) {
                                                         Box(
                                                             modifier = Modifier
-                                                                .size(80.dp),
+                                                                .size(80.adp()),
                                                             contentAlignment = Alignment.Center
                                                         ) {
                                                             AsyncImage(
@@ -2349,8 +2351,8 @@ fun AnimeDetailScreen(
                                                                 text = title,
                                                                 fontFamily = PoppinsBold,
                                                                 color = MaterialTheme.colorScheme.onSurface,
-                                                                fontSize = 18.sp,
-                                                                lineHeight = 22.sp,
+                                                                fontSize = 18.asp(),
+                                                                lineHeight = 22.asp(),
                                                                 maxLines = 2,
                                                                 overflow = TextOverflow.Ellipsis
                                                             )
@@ -2366,7 +2368,7 @@ fun AnimeDetailScreen(
                                                                     text = date ?: "",
                                                                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                                                                     fontFamily = PoppinsRegular,
-                                                                    fontSize = 12.sp
+                                                                    fontSize = 12.asp()
                                                                 )
                                                             }
                                                         }
@@ -2387,8 +2389,8 @@ fun AnimeDetailScreen(
                                                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
                                                         fontFamily = PoppinsRegular,
                                                         textAlign = TextAlign.Justify,
-                                                        lineHeight = 22.sp,
-                                                        fontSize = 13.sp,
+                                                        lineHeight = 22.asp(),
+                                                        fontSize = 13.asp(),
                                                         overflow = TextOverflow.Ellipsis,
                                                         maxLines = if (expandedProducerAbout) Int.MAX_VALUE else 4
                                                     )
@@ -2397,7 +2399,7 @@ fun AnimeDetailScreen(
                                                         Text(
                                                             text = if (expandedProducerAbout) "Ver menos" else "Ver más",
                                                             fontFamily = PoppinsBold,
-                                                            fontSize = 13.sp,
+                                                            fontSize = 13.asp(),
                                                             color = MaterialTheme.colorScheme.primary,
                                                             modifier = Modifier.clickable {
                                                                 expandedProducerAbout = !expandedProducerAbout
@@ -2436,7 +2438,7 @@ fun AnimeDetailScreen(
                                                                     imageVector = Icons.AutoMirrored.Filled.ArrowRight,
                                                                     contentDescription = null,
                                                                     tint = MaterialTheme.colorScheme.primary,
-                                                                    modifier = Modifier.size(16.dp)
+                                                                    modifier = Modifier.size(16.adp())
                                                                 )
                                                                 Text(
                                                                     text = external.name ?: "Enlace",
@@ -2444,7 +2446,7 @@ fun AnimeDetailScreen(
                                                                     overflow = TextOverflow.Ellipsis,
                                                                     color = MaterialTheme.colorScheme.primary,
                                                                     fontFamily = PoppinsMedium,
-                                                                    fontSize = 13.sp
+                                                                    fontSize = 13.asp()
                                                                 )
                                                             }
                                                         }
@@ -2519,7 +2521,7 @@ fun AnimeDetailScreen(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(56.dp)
+                    .height(56.adp())
             ) {
                 // Degradado siempre visible para legibilidad del botón volver
                 Box(
@@ -2557,7 +2559,7 @@ fun AnimeDetailScreen(
                 Text(
                     text = "Detalle del anime",
                     color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = 18.sp,
+                    fontSize = 18.asp(),
                     fontFamily = PoppinsBold,
                     modifier = Modifier
                         .align(Alignment.Center)
@@ -2667,13 +2669,13 @@ fun AnimeDetailScreen(
                             imageVector = Icons.Default.Favorite,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(24.dp)
+                            modifier = Modifier.size(24.adp())
                         )
                         Spacer(modifier = Modifier.width(12.dp))
                         Text(
                             text = if (isAdded) "Editar en mi lista" else "Añadir a mi lista",
                             color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 20.sp,
+                            fontSize = 20.asp(),
                             fontFamily = PoppinsBold
                         )
                     }
@@ -2684,7 +2686,7 @@ fun AnimeDetailScreen(
                     ) {
                         Text(
                             text = "Estado",
-                            fontSize = 16.sp,
+                            fontSize = 16.asp(),
                             fontFamily = PoppinsBold,
                             color = MaterialTheme.colorScheme.onSurface
                         )
@@ -2695,7 +2697,7 @@ fun AnimeDetailScreen(
 
                         LazyVerticalGrid(
                             columns = GridCells.Fixed(2),
-                            modifier = Modifier.height(180.dp),
+                            modifier = Modifier.height(180.adp()),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
@@ -2713,7 +2715,7 @@ fun AnimeDetailScreen(
                                         }
                                     },
                                     modifier = Modifier
-                                        .height(50.dp)
+                                        .height(50.adp())
                                         .then(if (isDisabled) Modifier.alpha(0.4f) else Modifier),
                                     shape = RoundedCornerShape(12.dp),
                                     color = if (isSelected)
@@ -2734,13 +2736,13 @@ fun AnimeDetailScreen(
                                                 Icon(
                                                     imageVector = Icons.Default.CheckCircle,
                                                     contentDescription = null,
-                                                    modifier = Modifier.size(16.dp),
+                                                    modifier = Modifier.size(16.adp()),
                                                     tint = Color.Black
                                                 )
                                             }
                                             Text(
                                                 text = status,
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 fontFamily = PoppinsRegular,
                                                 fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                                                 color = if (isSelected) Color.Black else MaterialTheme.colorScheme.onSurface
@@ -2763,7 +2765,7 @@ fun AnimeDetailScreen(
                         ) {
                             Text(
                                 text = "Prioridad",
-                                fontSize = 16.sp,
+                                fontSize = 16.asp(),
                                 fontFamily = PoppinsBold,
                                 color = MaterialTheme.colorScheme.onSurface
                             )
@@ -2781,7 +2783,7 @@ fun AnimeDetailScreen(
                                     val isSelected = plannedPriority == priority
                                     Surface(
                                         onClick = { plannedPriority = if (isSelected) null else priority },
-                                        modifier = Modifier.weight(1f).height(44.dp),
+                                        modifier = Modifier.weight(1f).height(44.adp()),
                                         shape = RoundedCornerShape(12.dp),
                                         color = if (isSelected)
                                             priorityColors[priority] ?: MaterialTheme.colorScheme.primaryContainer
@@ -2792,7 +2794,7 @@ fun AnimeDetailScreen(
                                         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                                             Text(
                                                 text = priority,
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 fontFamily = PoppinsRegular,
                                                 fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                                                 color = if (isSelected) Color.Black else MaterialTheme.colorScheme.onSurface
@@ -2803,7 +2805,7 @@ fun AnimeDetailScreen(
                             }
                             Text(
                                 text = "Nota del plan (opcional)",
-                                fontSize = 16.sp,
+                                fontSize = 16.asp(),
                                 fontFamily = PoppinsBold,
                                 color = MaterialTheme.colorScheme.onSurface
                             )
@@ -2811,7 +2813,7 @@ fun AnimeDetailScreen(
                                 value = plannedNote,
                                 onValueChange = { plannedNote = it },
                                 placeholder = { Text("¿Por qué lo tenés planeado?") },
-                                modifier = Modifier.fillMaxWidth().height(100.dp),
+                                modifier = Modifier.fillMaxWidth().height(100.adp()),
                                 colors = OutlinedTextFieldDefaults.colors(
                                     focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                                     unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -2843,7 +2845,7 @@ fun AnimeDetailScreen(
                             ) {
                                 Text(
                                     text = "Calificación",
-                                    fontSize = 16.sp,
+                                    fontSize = 16.asp(),
                                     fontFamily = PoppinsBold,
                                     color = MaterialTheme.colorScheme.onSurface
                                 )
@@ -2861,11 +2863,11 @@ fun AnimeDetailScreen(
                                                 imageVector = Icons.Default.Star,
                                                 contentDescription = null,
                                                 tint = Color(0xFFFFD700),
-                                                modifier = Modifier.size(16.dp)
+                                                modifier = Modifier.size(16.adp())
                                             )
                                             Text(
                                                 text = String.format("%.1f", userRating),
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = MaterialTheme.colorScheme.primary
                                             )
@@ -2891,7 +2893,7 @@ fun AnimeDetailScreen(
                     ) {
                         Text(
                             text = "Opinión (opcional)",
-                            fontSize = 16.sp,
+                            fontSize = 16.asp(),
                             fontFamily = PoppinsBold,
                             color = MaterialTheme.colorScheme.onSurface
                         )
@@ -2899,7 +2901,7 @@ fun AnimeDetailScreen(
                             value = userOpinion,
                             onValueChange = { userOpinion = it },
                             placeholder = { Text("Comparte tu opinión...") },
-                            modifier = Modifier.fillMaxWidth().height(120.dp),
+                            modifier = Modifier.fillMaxWidth().height(120.adp()),
                             colors = OutlinedTextFieldDefaults.colors(
                                 focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                                 unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -2920,7 +2922,7 @@ fun AnimeDetailScreen(
                     ) {
                         Text(
                             text = "Fechas (opcional)",
-                            fontSize = 16.sp,
+                            fontSize = 16.asp(),
                             fontFamily = PoppinsBold,
                             color = MaterialTheme.colorScheme.onSurface
                         )
@@ -2951,11 +2953,11 @@ fun AnimeDetailScreen(
                                             MaterialTheme.colorScheme.onSurfaceVariant
                                         else
                                             MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                                        modifier = Modifier.size(18.dp)
+                                        modifier = Modifier.size(18.adp())
                                     )
                                     Text(
                                         text = startDate?.let { dateFormat.format(it) } ?: "Inicio",
-                                        fontSize = 12.sp,
+                                        fontSize = 12.asp(),
                                         fontFamily = PoppinsRegular,
                                         color = if (canSelectStartDate)
                                             MaterialTheme.colorScheme.onSurface
@@ -2985,11 +2987,11 @@ fun AnimeDetailScreen(
                                             MaterialTheme.colorScheme.onSurfaceVariant
                                         else
                                             MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                                        modifier = Modifier.size(18.dp)
+                                        modifier = Modifier.size(18.adp())
                                     )
                                     Text(
                                         text = endDate?.let { dateFormat.format(it) } ?: "Final",
-                                        fontSize = 12.sp,
+                                        fontSize = 12.asp(),
                                         fontFamily = PoppinsRegular,
                                         color = if (canSelectEndDate)
                                             MaterialTheme.colorScheme.onSurface
@@ -3038,7 +3040,7 @@ fun AnimeDetailScreen(
                             }
                         },
                         enabled = isFormValid,
-                        modifier = Modifier.fillMaxWidth().height(54.dp),
+                        modifier = Modifier.fillMaxWidth().height(54.adp()),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.primary,
                             contentColor = MaterialTheme.colorScheme.onPrimary,
@@ -3052,8 +3054,8 @@ fun AnimeDetailScreen(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Icon(imageVector = Icons.Default.Check, contentDescription = null, modifier = Modifier.size(20.dp))
-                            Text(text = "Guardar en mi lista", fontSize = 16.sp, fontFamily = PoppinsBold)
+                            Icon(imageVector = Icons.Default.Check, contentDescription = null, modifier = Modifier.size(20.adp()))
+                            Text(text = "Guardar en mi lista", fontSize = 16.asp(), fontFamily = PoppinsBold)
                         }
                     }
 
@@ -3132,7 +3134,7 @@ fun AnimeDetailScreen(
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .height(200.dp),
+                                .height(200.adp()),
                             contentAlignment = Alignment.Center
                         ) {
                             CircularProgressIndicator(
@@ -3157,7 +3159,7 @@ fun AnimeDetailScreen(
                                     ) {
                                         Box(
                                             modifier = Modifier
-                                                .size(48.dp)
+                                                .size(48.adp())
                                                 .background(
                                                     MaterialTheme.colorScheme.primary,
                                                     RoundedCornerShape(8.dp)
@@ -3167,7 +3169,7 @@ fun AnimeDetailScreen(
                                             Text(
                                                 text = "${episode.malId ?: "?"}",
                                                 color = MaterialTheme.colorScheme.onPrimary,
-                                                fontSize = 18.sp,
+                                                fontSize = 18.asp(),
                                                 fontFamily = PoppinsBold
                                             )
                                         }
@@ -3237,13 +3239,13 @@ fun AnimeDetailScreen(
                                                 Icons.Default.Timer,
                                                 contentDescription = null,
                                                 tint = MaterialTheme.colorScheme.primary,
-                                                modifier = Modifier.size(18.dp)
+                                                modifier = Modifier.size(18.adp())
                                             )
                                             Spacer(modifier = Modifier.width(4.dp))
                                             Text(
                                                 text = "${episode.duration} seg",
                                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                                                fontSize = 13.sp,
+                                                fontSize = 13.asp(),
                                                 fontFamily = PoppinsMedium
                                             )
                                         }
@@ -3258,13 +3260,13 @@ fun AnimeDetailScreen(
                                                 Icons.Default.CalendarToday,
                                                 contentDescription = null,
                                                 tint = MaterialTheme.colorScheme.primary,
-                                                modifier = Modifier.size(18.dp)
+                                                modifier = Modifier.size(18.adp())
                                             )
                                             Spacer(modifier = Modifier.width(4.dp))
                                             Text(
                                                 text = episode.aired.substringBefore("T"),
                                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                                                fontSize = 13.sp,
+                                                fontSize = 13.asp(),
                                                 fontFamily = PoppinsMedium
                                             )
                                         }
@@ -3289,7 +3291,7 @@ fun AnimeDetailScreen(
                                             Text(
                                                 text = "Filler",
                                                 color = Color.White,
-                                                fontSize = 12.sp,
+                                                fontSize = 12.asp(),
                                                 fontFamily = PoppinsBold
                                             )
                                         }
@@ -3307,7 +3309,7 @@ fun AnimeDetailScreen(
                                             Text(
                                                 text = "Recap",
                                                 color = Color.White,
-                                                fontSize = 12.sp,
+                                                fontSize = 12.asp(),
                                                 fontFamily = PoppinsBold
                                             )
                                         }
@@ -3332,7 +3334,7 @@ fun AnimeDetailScreen(
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
                                         fontFamily = PoppinsRegular,
-                                        lineHeight = 22.sp
+                                        lineHeight = 22.asp()
                                     )
                                 }
 
@@ -3357,7 +3359,7 @@ fun AnimeDetailScreen(
                                         Icon(
                                             Icons.Default.OpenInNew,
                                             contentDescription = null,
-                                            modifier = Modifier.size(18.dp)
+                                            modifier = Modifier.size(18.adp())
                                         )
                                         Spacer(modifier = Modifier.width(8.dp))
                                         Text(
@@ -3391,12 +3393,12 @@ private fun InfoRow(
             imageVector = icon,
             contentDescription = null,
             tint = iconTint,
-            modifier = Modifier.size(20.dp)
+            modifier = Modifier.size(20.adp())
         )
         Text(
             text = text,
             color = MaterialTheme.colorScheme.onSurface,
-            fontSize = 16.sp,
+            fontSize = 16.asp(),
             fontWeight = if (isBold) FontWeight.Bold else FontWeight.Normal
         )
     }
@@ -3419,7 +3421,7 @@ fun ThemeItem(
         ) {
             Text(
                 text = title,
-                fontSize = 14.sp,
+                fontSize = 14.asp(),
                 fontFamily = PoppinsBold,
                 color = MaterialTheme.colorScheme.onSurface
             )
@@ -3439,7 +3441,7 @@ fun ThemeItem(
                         else
                             MaterialTheme.colorScheme.secondary,
                         fontFamily = PoppinsBold,
-                        fontSize = 11.sp
+                        fontSize = 11.asp()
                     )
                 }
             }
@@ -3450,7 +3452,7 @@ fun ThemeItem(
                 text = "No hay $title disponibles",
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                 fontFamily = PoppinsRegular,
-                fontSize = 13.sp
+                fontSize = 13.asp()
             )
         } else {
             FlowRow(
@@ -3487,7 +3489,7 @@ fun ThemeItem(
                                 text = theme,
                                 color = MaterialTheme.colorScheme.onSurface,
                                 fontFamily = PoppinsRegular,
-                                fontSize = 12.sp,
+                                fontSize = 12.asp(),
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis
                             )
@@ -3506,7 +3508,7 @@ fun QuickInfoItem(icon: ImageVector, text: String, iconColor: Color) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Icon(icon, null, tint = iconColor, modifier = Modifier.size(14.dp))
         Spacer(modifier = Modifier.width(4.dp))
-        Text(text, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface, fontFamily = PoppinsBold)
+        Text(text, fontSize = 13.asp(), color = MaterialTheme.colorScheme.onSurface, fontFamily = PoppinsBold)
     }
 }
 
@@ -3523,7 +3525,7 @@ fun DetailChip(icon: ImageVector, text: String) {
         ) {
             Icon(icon, null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.primary)
             Spacer(modifier = Modifier.width(6.dp))
-            Text(text, fontSize = 12.sp, fontFamily = PoppinsMedium)
+            Text(text, fontSize = 12.asp(), fontFamily = PoppinsMedium)
         }
     }
 }
@@ -3540,7 +3542,7 @@ fun DetailChipSmall(icon: ImageVector, text: String) {
         ) {
             Icon(icon, null, modifier = Modifier.size(10.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
             Spacer(modifier = Modifier.width(4.dp))
-            Text(text, fontSize = 10.sp, fontFamily = PoppinsMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(text, fontSize = 10.asp(), fontFamily = PoppinsMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
@@ -3573,7 +3575,7 @@ fun SectionHeader(
                     text = title,
                     style = TextStyle(
                         fontFamily = PoppinsBold,
-                        fontSize = 22.sp,
+                        fontSize = 22.asp(),
                         letterSpacing = (-0.5).sp,
                         color = MaterialTheme.colorScheme.onSurface
                     )
@@ -3582,7 +3584,7 @@ fun SectionHeader(
                     text = subtitle,
                     style = TextStyle(
                         fontFamily = PoppinsRegular,
-                        fontSize = 12.sp,
+                        fontSize = 12.asp(),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
                     )
                 )
@@ -3622,7 +3624,7 @@ fun StatusChip(status: String) {
             Text(
                 text = statusLabel,
                 color = statusFg,
-                fontSize = 11.sp,
+                fontSize = 11.asp(),
                 fontFamily = PoppinsBold,
                 letterSpacing = 0.5.sp
             )
@@ -3648,7 +3650,7 @@ fun StateMessage(
         Icon(
             imageVector = icon,
             contentDescription = null,
-            modifier = Modifier.size(64.dp),
+            modifier = Modifier.size(64.adp()),
             tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)
         )
         Spacer(modifier = Modifier.height(16.dp))
@@ -3699,7 +3701,7 @@ fun OtherTitleItem(label: String, value: String?) {
                     color = MaterialTheme.colorScheme.primary,
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
-                    fontSize = 12.sp
+                    fontSize = 12.asp()
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
@@ -3736,7 +3738,7 @@ fun InfoGridItem(
                     imageVector = icon,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.secondary,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(20.adp())
                 )
                 Spacer(modifier = Modifier.width(12.dp))
                 Text(
@@ -3777,14 +3779,14 @@ private fun CompactInfoRow(
     ) {
         Text(
             text = label,
-            fontSize = 13.sp,
+            fontSize = 13.asp(),
             fontFamily = PoppinsRegular,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(0.5f)
         )
         Text(
             text = value,
-            fontSize = 13.sp,
+            fontSize = 13.asp(),
             fontFamily = PoppinsBold,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(0.5f),
@@ -3835,7 +3837,7 @@ fun RatingBar(
                     contentDescription = "Puntuación de $starValue estrellas",
                     modifier = Modifier
                         .scale(size)
-                        .size(32.dp)
+                        .size(32.adp())
                         .clickable {
                             val newRating = if (rating == starValue) {
                                 starValue - 0.5f
@@ -3858,7 +3860,7 @@ fun RatingBar(
                 "Tu calificación: %.1f / %d".format(rating, stars)
             },
             color = MaterialTheme.colorScheme.onSurface,
-            fontSize = 16.sp,
+            fontSize = 16.asp(),
             fontWeight = FontWeight.Bold,
             fontFamily = PoppinsBold,
             modifier = Modifier
@@ -3941,7 +3943,7 @@ private fun StudioCompactCard(
             ) {
                 Box(
                     modifier = Modifier
-                        .size(44.dp)
+                        .size(44.adp())
                         .background(
                             MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
                             RoundedCornerShape(12.dp)
@@ -3952,7 +3954,7 @@ private fun StudioCompactCard(
                         imageVector = Icons.Default.Business,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(22.dp)
+                        modifier = Modifier.size(22.adp())
                     )
                 }
 
@@ -3964,23 +3966,23 @@ private fun StudioCompactCard(
                         text = studioName,
                         color = MaterialTheme.colorScheme.onSurface,
                         fontFamily = PoppinsBold,
-                        fontSize = 15.sp,
+                        fontSize = 15.asp(),
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
-                        lineHeight = 20.sp
+                        lineHeight = 20.asp()
                     )
                     Text(
                         text = if (isExpanded) "Toca para cerrar" else "Toca para ver detalles",
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
                         fontFamily = PoppinsRegular,
-                        fontSize = 11.sp
+                        fontSize = 11.asp()
                     )
                 }
             }
 
             Box(
                 modifier = Modifier
-                    .size(32.dp)
+                    .size(32.adp())
                     .background(
                         MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
                         RoundedCornerShape(10.dp)
@@ -3992,7 +3994,7 @@ private fun StudioCompactCard(
                     contentDescription = if (isExpanded) "Contraer" else "Expandir",
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier
-                        .size(22.dp)
+                        .size(22.adp())
                         .rotate(rotationAngle)
                 )
             }
@@ -4010,7 +4012,7 @@ private fun VideoCard(
 ) {
     Card(
         modifier = Modifier
-            .width(200.dp)
+            .width(200.adp())
             .clickable {
                 youtubeUrl?.let { url ->
                     try {
@@ -4034,7 +4036,7 @@ private fun VideoCard(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(112.dp)
+                    .height(112.adp())
                     .background(MaterialTheme.colorScheme.surfaceContainerHighest)
             ) {
                 if (!thumbnailUrl.isNullOrBlank()) {
@@ -4056,7 +4058,7 @@ private fun VideoCard(
                         imageVector = Icons.Default.PlayCircle,
                         contentDescription = "Play",
                         tint = Color.White,
-                        modifier = Modifier.size(48.dp)
+                        modifier = Modifier.size(48.adp())
                     )
                 }
             }
@@ -4069,7 +4071,7 @@ private fun VideoCard(
                 Text(
                     text = title,
                     color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = 13.sp,
+                    fontSize = 13.asp(),
                     fontFamily = PoppinsMedium,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
@@ -4079,7 +4081,7 @@ private fun VideoCard(
                     Text(
                         text = subtitle,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                        fontSize = 11.sp,
+                        fontSize = 11.asp(),
                         fontFamily = PoppinsRegular,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
@@ -4100,7 +4102,7 @@ private fun EpisodeCard(
 ) {
     Card(
         modifier = Modifier
-            .width(160.dp)
+            .width(160.adp())
             .clickable {
                 url?.let { link ->
                     try {
@@ -4118,7 +4120,7 @@ private fun EpisodeCard(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(90.dp)
+                    .height(90.adp())
                     .background(MaterialTheme.colorScheme.surfaceContainerHighest)
             ) {
                 if (!imageUrl.isNullOrBlank()) {
@@ -4137,7 +4139,7 @@ private fun EpisodeCard(
                             imageVector = Icons.Default.OndemandVideo,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
-                            modifier = Modifier.size(32.dp)
+                            modifier = Modifier.size(32.adp())
                         )
                     }
                 }
@@ -4156,7 +4158,7 @@ private fun EpisodeCard(
                         Text(
                             text = episode,
                             color = MaterialTheme.colorScheme.onPrimary,
-                            fontSize = 10.sp,
+                            fontSize = 10.asp(),
                             fontFamily = PoppinsBold
                         )
                     }
@@ -4191,7 +4193,7 @@ private fun EpisodeListItem(
             // Episode number badge
             Box(
                 modifier = Modifier
-                    .size(48.dp)
+                    .size(48.adp())
                     .background(
                         MaterialTheme.colorScheme.primary,
                         RoundedCornerShape(8.dp)
@@ -4201,7 +4203,7 @@ private fun EpisodeListItem(
                 Text(
                     text = "${episode.malId ?: "?"}",
                     color = MaterialTheme.colorScheme.onPrimary,
-                    fontSize = 16.sp,
+                    fontSize = 16.asp(),
                     fontFamily = PoppinsBold
                 )
             }
@@ -4215,7 +4217,7 @@ private fun EpisodeListItem(
                 Text(
                     text = episode.title ?: "Episodio ${episode.malId}",
                     color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = 14.sp,
+                    fontSize = 14.asp(),
                     fontFamily = PoppinsMedium,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
@@ -4225,7 +4227,7 @@ private fun EpisodeListItem(
                     Text(
                         text = episode.titleJapanese,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                        fontSize = 12.sp,
+                        fontSize = 12.asp(),
                         fontFamily = PoppinsRegular,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
@@ -4241,7 +4243,7 @@ private fun EpisodeListItem(
                         Text(
                             text = episode.aired.substringBefore("T"),
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-                            fontSize = 11.sp,
+                            fontSize = 11.asp(),
                             fontFamily = PoppinsRegular
                         )
                     }
@@ -4261,7 +4263,7 @@ private fun EpisodeListItem(
                             Text(
                                 text = String.format("%.1f", episode.score),
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                                fontSize = 11.sp,
+                                fontSize = 11.asp(),
                                 fontFamily = PoppinsMedium
                             )
                         }
@@ -4280,7 +4282,7 @@ private fun EpisodeListItem(
                             Text(
                                 text = "Filler",
                                 color = Color(0xFFFF9800),
-                                fontSize = 10.sp,
+                                fontSize = 10.asp(),
                                 fontFamily = PoppinsMedium
                             )
                         }
@@ -4298,7 +4300,7 @@ private fun EpisodeListItem(
                             Text(
                                 text = "Recap",
                                 color = Color(0xFF9C27B0),
-                                fontSize = 10.sp,
+                                fontSize = 10.asp(),
                                 fontFamily = PoppinsMedium
                             )
                         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/home/HomeScreen.kt
@@ -132,6 +132,8 @@ import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsMedium
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import kotlinx.coroutines.delay
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 
 // HomeScreen con UI mejorada
@@ -410,7 +412,7 @@ private fun AnimeContent(
                 })
         }
         item {
-            Spacer(Modifier.height(80.dp))
+            Spacer(Modifier.height(80.adp()))
         }
     }
 }
@@ -525,7 +527,7 @@ private fun AnimeSectionHeader(
                 // Contenedor del icono con fondo
                 Box(
                     modifier = Modifier
-                        .size(40.dp)
+                        .size(40.adp())
                         .clip(RoundedCornerShape(10.dp))
                         .background(
                             brush = Brush.linearGradient(
@@ -540,7 +542,7 @@ private fun AnimeSectionHeader(
                         imageVector = icon,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(22.dp)
+                        modifier = Modifier.size(22.adp())
                     )
                 }
 
@@ -548,7 +550,7 @@ private fun AnimeSectionHeader(
                 Text(
                     text = title,
                     color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = 21.sp,
+                    fontSize = 21.asp(),
                     fontFamily = PoppinsBold,
                     letterSpacing = 0.3.sp
                 )
@@ -591,7 +593,7 @@ private fun AnimeSectionHeader(
                 }
             ) {
                 Text(
-                    text = "Ver más", fontSize = 13.sp, fontFamily = PoppinsMedium
+                    text = "Ver más", fontSize = 13.asp(), fontFamily = PoppinsMedium
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Icon(
@@ -652,7 +654,7 @@ fun FilterAnimesHome(
                     Text(
                         text = listLabel[index], style = TextStyle(
                             fontFamily = if (isSelected) PoppinsBold else PoppinsRegular,
-                            fontSize = 14.sp,
+                            fontSize = 14.asp(),
                             color = contentColor // Aplicamos la animación al texto
                         )
                     )
@@ -662,7 +664,7 @@ fun FilterAnimesHome(
                         Icon(
                             imageVector = Icons.Default.Check,
                             contentDescription = null,
-                            modifier = Modifier.size(16.dp),
+                            modifier = Modifier.size(16.adp()),
                             tint = contentColor // Aplicamos la animación al icono
                         )
                     }
@@ -714,7 +716,7 @@ private fun EnhancedEmptyState(message: String) {
             // Icono con diseño circular
             Box(
                 modifier = Modifier
-                    .size(56.dp)
+                    .size(56.adp())
                     .clip(CircleShape)
                     .background(
                         brush = Brush.radialGradient(
@@ -729,7 +731,7 @@ private fun EnhancedEmptyState(message: String) {
                     imageVector = Icons.Default.Info,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
-                    modifier = Modifier.size(28.dp)
+                    modifier = Modifier.size(28.adp())
                 )
             }
 
@@ -737,9 +739,9 @@ private fun EnhancedEmptyState(message: String) {
             Text(
                 text = message,
                 fontFamily = PoppinsRegular,
-                fontSize = 14.sp,
+                fontSize = 14.asp(),
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
-                lineHeight = 20.sp,
+                lineHeight = 20.asp(),
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(horizontal = 8.dp)
             )
@@ -850,7 +852,7 @@ private fun HeroPlaceholderCard(color: Color) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .height(190.dp),
+            .height(190.adp()),
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(8.dp),
         colors = CardDefaults.cardColors(containerColor = color)
@@ -888,7 +890,7 @@ private fun HeroAnimeCard(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .height(190.dp)
+            .height(190.adp())
             .graphicsLayer { scaleX = scale; scaleY = scale },
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(8.dp),
@@ -963,7 +965,7 @@ private fun HeroAnimeCard(
                     Text(
                         text = item.label,
                         fontFamily = PoppinsBold,
-                        fontSize = 9.sp,
+                        fontSize = 9.asp(),
                         letterSpacing = 0.8.sp,
                         color = Color.White
                     )
@@ -980,8 +982,8 @@ private fun HeroAnimeCard(
                 Text(
                     text = item.title,
                     fontFamily = PoppinsBold,
-                    fontSize = 16.sp,
-                    lineHeight = 20.sp,
+                    fontSize = 16.asp(),
+                    lineHeight = 20.asp(),
                     color = Color.White,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
@@ -1011,7 +1013,7 @@ private fun HeroAnimeCard(
                             Text(
                                 text = String.format(java.util.Locale.US, "%.1f", score),
                                 fontFamily = PoppinsMedium,
-                                fontSize = 12.sp,
+                                fontSize = 12.asp(),
                                 color = Color.White
                             )
                         }
@@ -1020,7 +1022,7 @@ private fun HeroAnimeCard(
                         Text(
                             text = it,
                             fontFamily = PoppinsRegular,
-                            fontSize = 12.sp,
+                            fontSize = 12.asp(),
                             color = Color.White.copy(alpha = 0.8f)
                         )
                     }
@@ -1028,7 +1030,7 @@ private fun HeroAnimeCard(
                         Text(
                             text = it,
                             fontFamily = PoppinsRegular,
-                            fontSize = 12.sp,
+                            fontSize = 12.asp(),
                             color = Color.White.copy(alpha = 0.8f)
                         )
                     }
@@ -1075,7 +1077,7 @@ fun ScoreBadge(
             Text(
                 text = formattedScore,
                 fontFamily = PoppinsMedium,
-                fontSize = 12.sp,
+                fontSize = 12.asp(),
                 color = Color.White
             )
         }
@@ -1088,7 +1090,7 @@ fun SectionLabel() {
     Text(
         text = "Anime Random",
         fontFamily = PoppinsBold,
-        fontSize = 10.sp,
+        fontSize = 10.asp(),
         letterSpacing = 1.4.sp,
         color = MaterialTheme.colorScheme.primary
     )
@@ -1109,7 +1111,7 @@ fun DetailsButton() {
             Text(
                 "Ver detalles",
                 fontFamily = PoppinsMedium,
-                fontSize = 13.sp,
+                fontSize = 13.asp(),
                 color = MaterialTheme.colorScheme.primary
             )
 
@@ -1136,7 +1138,7 @@ fun MetadataItemModern(text: String, icon: ImageVector) {
         Text(
             text = text,
             fontFamily = PoppinsRegular,
-            fontSize = 12.sp,
+            fontSize = 12.asp(),
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
@@ -1149,7 +1151,7 @@ private fun HeroBannerSkeleton() {
     androidx.compose.material3.Card(
         modifier = Modifier
             .fillMaxWidth()
-            .height(180.dp)
+            .height(180.adp())
             .padding(horizontal = 16.dp),
         shape = RoundedCornerShape(20.dp),
         colors = androidx.compose.material3.CardDefaults.cardColors(
@@ -1161,7 +1163,7 @@ private fun HeroBannerSkeleton() {
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .width(130.dp)
+                    .width(130.adp())
                     .background(
                         shimmerBrush(
                             targetValue = 1000f, showShimmer = true
@@ -1187,7 +1189,7 @@ private fun HeroBannerSkeleton() {
                         // Label skeleton
                         Box(
                             modifier = Modifier
-                                .width(90.dp)
+                                .width(90.adp())
                                 .height(14.dp)
                                 .clip(RoundedCornerShape(4.dp))
                                 .background(
@@ -1237,7 +1239,7 @@ private fun HeroBannerSkeleton() {
                             )
                             Box(
                                 modifier = Modifier
-                                    .width(60.dp)
+                                    .width(60.adp())
                                     .height(14.dp)
                                     .clip(RoundedCornerShape(4.dp))
                                     .background(
@@ -1252,7 +1254,7 @@ private fun HeroBannerSkeleton() {
                     // Score skeleton (inferior)
                     Box(
                         modifier = Modifier
-                            .width(80.dp)
+                            .width(80.adp())
                             .height(24.dp)
                             .clip(RoundedCornerShape(6.dp))
                             .background(
@@ -1358,7 +1360,7 @@ private fun QuickStats(
                     ) {
                         Box(
                             modifier = Modifier
-                                .size(42.dp)
+                                .size(42.adp())
                                 .background(
                                     MaterialTheme.colorScheme.primaryContainer,
                                     RoundedCornerShape(12.dp)
@@ -1369,30 +1371,30 @@ private fun QuickStats(
                                 imageVector = Icons.AutoMirrored.Filled.TrendingUp,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                                modifier = Modifier.size(22.dp)
+                                modifier = Modifier.size(22.adp())
                             )
                         }
                         Column {
                             Text(
                                 text = "Tu Progreso",
                                 fontFamily = PoppinsBold,
-                                fontSize = 16.sp,
+                                fontSize = 16.asp(),
                                 color = MaterialTheme.colorScheme.onSurface,
-                                lineHeight = 18.sp
+                                lineHeight = 18.asp()
                             )
                             Text(
                                 text = "${stats.totalAnimes} animes en tu lista",
                                 fontFamily = PoppinsRegular,
-                                fontSize = 12.sp,
+                                fontSize = 12.asp(),
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                lineHeight = 15.sp
+                                lineHeight = 15.asp()
                             )
                         }
                     }
 
                     // Botón expandir — estilo outlined
                     Surface(
-                        modifier = Modifier.size(32.dp),
+                        modifier = Modifier.size(32.adp()),
                         shape = CircleShape,
                         color = Color.Transparent,
                         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
@@ -1403,7 +1405,7 @@ private fun QuickStats(
                                 imageVector = Icons.Default.KeyboardArrowDown,
                                 contentDescription = null,
                                 modifier = Modifier
-                                    .size(18.dp)
+                                    .size(18.adp())
                                     .rotate(rotationAngle),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
@@ -1491,7 +1493,7 @@ private fun QuickStats(
                             Text(
                                 text = "Continuar viendo",
                                 fontFamily = PoppinsBold,
-                                fontSize = 14.sp,
+                                fontSize = 14.asp(),
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.padding(bottom = 12.dp)
                             )
@@ -1533,7 +1535,7 @@ private fun NarrativeStatCard(
     ) {
         Box(
             modifier = Modifier
-                .size(36.dp)
+                .size(36.adp())
                 .background(iconTint.copy(alpha = 0.20f), CircleShape),
             contentAlignment = Alignment.Center
         ) {
@@ -1541,15 +1543,15 @@ private fun NarrativeStatCard(
                 imageVector = icon,
                 contentDescription = null,
                 tint = iconTint,
-                modifier = Modifier.size(18.dp)
+                modifier = Modifier.size(18.adp())
             )
         }
         Text(
             text       = text,
             fontFamily = PoppinsRegular,
-            fontSize   = 13.sp,
+            fontSize = 13.asp(),
             color      = MaterialTheme.colorScheme.onSurface,
-            lineHeight = 19.sp
+            lineHeight = 19.asp()
         )
     }
 }
@@ -1575,7 +1577,7 @@ private fun EnhancedStatCard(
         ), modifier = modifier
     ) {
         androidx.compose.material3.Card(
-            modifier = Modifier.height(70.dp),
+            modifier = Modifier.height(70.adp()),
             shape = RoundedCornerShape(14.dp),
             colors = androidx.compose.material3.CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
@@ -1593,7 +1595,7 @@ private fun EnhancedStatCard(
                 Text(
                     text = label,
                     fontFamily = PoppinsRegular,
-                    fontSize = 11.sp,
+                    fontSize = 11.asp(),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                     letterSpacing = 0.3.sp
                 )
@@ -1601,10 +1603,10 @@ private fun EnhancedStatCard(
                 Text(
                     text = value,
                     fontFamily = PoppinsBold,
-                    fontSize = 26.sp,
+                    fontSize = 26.asp(),
                     color = MaterialTheme.colorScheme.primary,
                     letterSpacing = 0.sp,
-                    lineHeight = 26.sp
+                    lineHeight = 26.asp()
                 )
             }
         }
@@ -1639,7 +1641,7 @@ private fun EnhancedContinueWatchingCard(
 
     Card(
         modifier = modifier
-            .height(150.dp) // Un poco más de altura para que respire
+            .height(150.adp()) // Un poco más de altura para que respire
             .graphicsLayer {
                 scaleX = scale
                 scaleY = scale
@@ -1685,7 +1687,7 @@ private fun EnhancedContinueWatchingCard(
                 Text(
                     text = anime.title, style = TextStyle(
                         fontFamily = PoppinsBold,
-                        fontSize = 12.sp,
+                        fontSize = 12.asp(),
                         color = Color.White,
                         shadow = Shadow(Color.Black, Offset(0f, 2f), 4f)
                     ), maxLines = 1, overflow = TextOverflow.Ellipsis
@@ -1733,7 +1735,7 @@ private fun EnhancedContinueWatchingCard(
                                 modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp),
                                 style = TextStyle(
                                     fontFamily = PoppinsMedium,
-                                    fontSize = 9.sp,
+                                    fontSize = 9.asp(),
                                     color = Color.White.copy(alpha = 0.9f)
                                 )
                             )
@@ -1742,7 +1744,7 @@ private fun EnhancedContinueWatchingCard(
                         Text(
                             text = "${(progress * 100).toInt()}%", style = TextStyle(
                                 fontFamily = PoppinsBold,
-                                fontSize = 10.sp,
+                                fontSize = 10.asp(),
                                 color = MaterialTheme.colorScheme.primary
                             )
                         )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/local_anime_detail/LocalAnimeDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/local_anime_detail/LocalAnimeDetailScreen.kt
@@ -112,6 +112,8 @@ import com.yumedev.seijakulist.ui.theme.PoppinsMedium
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -236,7 +238,7 @@ fun AnimeDetailScreenLocal(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(56.dp)
+                            .height(56.adp())
                     ) {
                         IconButton(
                             onClick = { navController.popBackStack() },
@@ -251,7 +253,7 @@ fun AnimeDetailScreenLocal(
                         Text(
                             text = "Mi Anime",
                             color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 20.sp,
+                            fontSize = 20.asp(),
                             fontFamily = PoppinsBold,
                             modifier = Modifier.align(Alignment.Center)
                         )
@@ -262,7 +264,7 @@ fun AnimeDetailScreenLocal(
                         ) {
                             if (isSharing) {
                                 CircularProgressIndicator(
-                                    modifier = Modifier.size(24.dp),
+                                    modifier = Modifier.size(24.adp()),
                                     strokeWidth = 2.dp,
                                     color = MaterialTheme.colorScheme.onSurface
                                 )
@@ -285,7 +287,7 @@ fun AnimeDetailScreenLocal(
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .height(320.dp)
+                                .height(320.adp())
                         ) {
                             // Fondo borroso
                             Image(
@@ -337,8 +339,8 @@ fun AnimeDetailScreenLocal(
                                 // Imagen del anime con sombra
                                 Card(
                                     modifier = Modifier
-                                        .width(140.dp)
-                                        .height(210.dp),
+                                        .width(140.adp())
+                                        .height(210.adp()),
                                     shape = RoundedCornerShape(16.dp),
                                     elevation = CardDefaults.cardElevation(defaultElevation = 12.dp)
                                 ) {
@@ -362,11 +364,11 @@ fun AnimeDetailScreenLocal(
                                     Text(
                                         text = currentAnime.title,
                                         color = MaterialTheme.colorScheme.onSurface,
-                                        fontSize = 20.sp,
+                                        fontSize = 20.asp(),
                                         fontFamily = PoppinsBold,
                                         maxLines = 4,
                                         overflow = TextOverflow.Ellipsis,
-                                        lineHeight = 24.sp
+                                        lineHeight = 24.asp()
                                     )
 
                                     Spacer(modifier = Modifier.height(12.dp))
@@ -380,7 +382,7 @@ fun AnimeDetailScreenLocal(
                                             imageVector = Icons.Default.Star,
                                             contentDescription = "Tu puntuación",
                                             tint = Color(0xFFFFD700),
-                                            modifier = Modifier.size(22.dp)
+                                            modifier = Modifier.size(22.adp())
                                         )
                                         Text(
                                             text = if (currentAnime.userScore % 1.0 == 0.0) {
@@ -389,7 +391,7 @@ fun AnimeDetailScreenLocal(
                                                 "${currentAnime.userScore}/10"
                                             },
                                             color = MaterialTheme.colorScheme.onSurface,
-                                            fontSize = 18.sp,
+                                            fontSize = 18.asp(),
                                             fontFamily = PoppinsBold
                                         )
                                     }
@@ -408,7 +410,7 @@ fun AnimeDetailScreenLocal(
                                         Text(
                                             text = currentAnime.userStatus,
                                             color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                            fontSize = 13.sp,
+                                            fontSize = 13.asp(),
                                             fontFamily = PoppinsBold,
                                             modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
                                         )
@@ -436,10 +438,10 @@ fun AnimeDetailScreenLocal(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = 20.dp, vertical = 12.dp)
-                                .height(50.dp),
+                                .height(50.adp()),
                             shape = RoundedCornerShape(12.dp)
                         ) {
-                            Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(18.adp()))
                             Spacer(modifier = Modifier.width(8.dp))
                             Text("Editar anime", fontFamily = PoppinsBold)
                         }
@@ -477,18 +479,18 @@ fun AnimeDetailScreenLocal(
                                             imageVector = Icons.Default.Tv,
                                             contentDescription = "Episodios",
                                             tint = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(20.dp)
+                                            modifier = Modifier.size(20.adp())
                                         )
                                         Text(
                                             text = "Episodios vistos",
-                                            fontSize = 14.sp,
+                                            fontSize = 14.asp(),
                                             fontFamily = PoppinsRegular,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant
                                         )
                                     }
                                     Text(
                                         text = "${currentAnime.episodesWatched}/${currentAnime.totalEpisodes ?: "?"}",
-                                        fontSize = 16.sp,
+                                        fontSize = 16.asp(),
                                         fontFamily = PoppinsBold,
                                         color = MaterialTheme.colorScheme.onSurface
                                     )
@@ -512,18 +514,18 @@ fun AnimeDetailScreenLocal(
                                             imageVector = Icons.Default.Autorenew,
                                             contentDescription = "Veces visto",
                                             tint = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(20.dp)
+                                            modifier = Modifier.size(20.adp())
                                         )
                                         Text(
                                             text = "Veces visto",
-                                            fontSize = 14.sp,
+                                            fontSize = 14.asp(),
                                             fontFamily = PoppinsRegular,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant
                                         )
                                     }
                                     Text(
                                         text = "${currentAnime.rewatchCount}",
-                                        fontSize = 16.sp,
+                                        fontSize = 16.asp(),
                                         fontFamily = PoppinsBold,
                                         color = MaterialTheme.colorScheme.onSurface
                                     )
@@ -552,7 +554,7 @@ fun AnimeDetailScreenLocal(
                                             Text(
                                                 text = "Prioridad",
                                                 fontFamily = PoppinsBold,
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 color = MaterialTheme.colorScheme.onSurface
                                             )
 
@@ -574,7 +576,7 @@ fun AnimeDetailScreenLocal(
                                                         },
                                                         modifier = Modifier
                                                             .weight(1f)
-                                                            .height(40.dp),
+                                                            .height(40.adp()),
                                                         shape = RoundedCornerShape(10.dp),
                                                         color = if (isSelected)
                                                             priorityColors[priority] ?: MaterialTheme.colorScheme.primaryContainer
@@ -588,7 +590,7 @@ fun AnimeDetailScreenLocal(
                                                         ) {
                                                             Text(
                                                                 text = priority,
-                                                                fontSize = 13.sp,
+                                                                fontSize = 13.asp(),
                                                                 fontFamily = PoppinsRegular,
                                                                 fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                                                                 color = if (isSelected) Color.Black else MaterialTheme.colorScheme.onSurface
@@ -601,7 +603,7 @@ fun AnimeDetailScreenLocal(
                                             Text(
                                                 text = "Nota del plan",
                                                 fontFamily = PoppinsBold,
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 color = MaterialTheme.colorScheme.onSurface
                                             )
 
@@ -611,7 +613,7 @@ fun AnimeDetailScreenLocal(
                                                 placeholder = { Text("¿Por qué lo tenés planeado?") },
                                                 modifier = Modifier
                                                     .fillMaxWidth()
-                                                    .height(100.dp),
+                                                    .height(100.adp()),
                                                 colors = OutlinedTextFieldDefaults.colors(
                                                     focusedBorderColor = MaterialTheme.colorScheme.primary,
                                                     focusedTextColor = MaterialTheme.colorScheme.onSurface,
@@ -674,11 +676,11 @@ fun AnimeDetailScreenLocal(
                                                 imageVector = Icons.Default.Flag,
                                                 contentDescription = "Prioridad",
                                                 tint = MaterialTheme.colorScheme.primary,
-                                                modifier = Modifier.size(20.dp)
+                                                modifier = Modifier.size(20.adp())
                                             )
                                             Text(
                                                 text = "Prioridad del plan",
-                                                fontSize = 16.sp,
+                                                fontSize = 16.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = MaterialTheme.colorScheme.onSurface
                                             )
@@ -694,7 +696,7 @@ fun AnimeDetailScreenLocal(
                                                 imageVector = Icons.Default.Edit,
                                                 contentDescription = "Editar prioridad",
                                                 tint = MaterialTheme.colorScheme.primary,
-                                                modifier = Modifier.size(20.dp)
+                                                modifier = Modifier.size(20.adp())
                                             )
                                         }
                                     }
@@ -711,7 +713,7 @@ fun AnimeDetailScreenLocal(
                                     ) {
                                         Text(
                                             text = "Prioridad",
-                                            fontSize = 14.sp,
+                                            fontSize = 14.asp(),
                                             fontFamily = PoppinsRegular,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant
                                         )
@@ -730,7 +732,7 @@ fun AnimeDetailScreenLocal(
                                         ) {
                                             Text(
                                                 text = currentAnime.plannedPriority ?: "Sin definir",
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = if (currentAnime.plannedPriority != null) priorityColor
                                                 else MaterialTheme.colorScheme.onSurfaceVariant,
@@ -746,13 +748,13 @@ fun AnimeDetailScreenLocal(
                                         )
                                         Text(
                                             text = "Nota",
-                                            fontSize = 14.sp,
+                                            fontSize = 14.asp(),
                                             fontFamily = PoppinsRegular,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant
                                         )
                                         Text(
                                             text = currentAnime.plannedNote,
-                                            fontSize = 14.sp,
+                                            fontSize = 14.asp(),
                                             fontFamily = PoppinsRegular,
                                             color = MaterialTheme.colorScheme.onSurface
                                         )
@@ -784,7 +786,7 @@ fun AnimeDetailScreenLocal(
                                 ) {
                                     Text(
                                         text = "Géneros",
-                                        fontSize = 16.sp,
+                                        fontSize = 16.asp(),
                                         fontFamily = PoppinsBold,
                                         color = MaterialTheme.colorScheme.onSurface
                                     )
@@ -808,7 +810,7 @@ fun AnimeDetailScreenLocal(
                                                     text = genre,
                                                     color = MaterialTheme.colorScheme.onPrimaryContainer,
                                                     fontFamily = PoppinsRegular,
-                                                    fontSize = 13.sp,
+                                                    fontSize = 13.asp(),
                                                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
                                                 )
                                             }
@@ -841,17 +843,17 @@ fun AnimeDetailScreenLocal(
                                 ) {
                                     Text(
                                         text = "Sinopsis",
-                                        fontSize = 16.sp,
+                                        fontSize = 16.asp(),
                                         fontFamily = PoppinsBold,
                                         color = MaterialTheme.colorScheme.onSurface
                                     )
                                     Text(
                                         text = currentAnime.synopsis,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        fontSize = 14.sp,
+                                        fontSize = 14.asp(),
                                         fontFamily = PoppinsRegular,
                                         textAlign = TextAlign.Justify,
-                                        lineHeight = 20.sp
+                                        lineHeight = 20.asp()
                                     )
                                 }
                             }
@@ -880,7 +882,7 @@ fun AnimeDetailScreenLocal(
                                 ) {
                                     Text(
                                         text = "Otros títulos",
-                                        fontSize = 16.sp,
+                                        fontSize = 16.asp(),
                                         fontFamily = PoppinsBold,
                                         color = MaterialTheme.colorScheme.onSurface
                                     )
@@ -889,13 +891,13 @@ fun AnimeDetailScreenLocal(
                                         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                             Text(
                                                 text = "Inglés",
-                                                fontSize = 12.sp,
+                                                fontSize = 12.asp(),
                                                 fontFamily = PoppinsRegular,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                                             )
                                             Text(
                                                 text = currentAnime.titleEnglish,
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = MaterialTheme.colorScheme.onSurface
                                             )
@@ -911,13 +913,13 @@ fun AnimeDetailScreenLocal(
                                         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                             Text(
                                                 text = "Japonés",
-                                                fontSize = 12.sp,
+                                                fontSize = 12.asp(),
                                                 fontFamily = PoppinsRegular,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                                             )
                                             Text(
                                                 text = currentAnime.titleJapanese,
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = MaterialTheme.colorScheme.onSurface
                                             )
@@ -950,7 +952,7 @@ fun AnimeDetailScreenLocal(
                                 ) {
                                     Text(
                                         text = "Estudio",
-                                        fontSize = 16.sp,
+                                        fontSize = 16.asp(),
                                         fontFamily = PoppinsBold,
                                         color = MaterialTheme.colorScheme.onSurface
                                     )
@@ -974,7 +976,7 @@ fun AnimeDetailScreenLocal(
                                                     text = studio,
                                                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                                                     fontFamily = PoppinsRegular,
-                                                    fontSize = 13.sp,
+                                                    fontSize = 13.asp(),
                                                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
                                                 )
                                             }
@@ -1006,7 +1008,7 @@ fun AnimeDetailScreenLocal(
                             ) {
                                 Text(
                                     text = "Información",
-                                    fontSize = 16.sp,
+                                    fontSize = 16.asp(),
                                     fontFamily = PoppinsBold,
                                     color = MaterialTheme.colorScheme.onSurface,
                                     modifier = Modifier.padding(bottom = 4.dp)
@@ -1074,7 +1076,7 @@ fun AnimeDetailScreenLocal(
                             ) {
                                 Text(
                                     text = "Seguimiento",
-                                    fontSize = 16.sp,
+                                    fontSize = 16.asp(),
                                     fontFamily = PoppinsBold,
                                     color = MaterialTheme.colorScheme.onSurface
                                 )
@@ -1094,18 +1096,18 @@ fun AnimeDetailScreenLocal(
                                             imageVector = Icons.Default.CalendarToday,
                                             contentDescription = null,
                                             tint = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(18.dp)
+                                            modifier = Modifier.size(18.adp())
                                         )
                                         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                                             Text(
                                                 text = "Inicio",
-                                                fontSize = 12.sp,
+                                                fontSize = 12.asp(),
                                                 fontFamily = PoppinsRegular,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                                             )
                                             Text(
                                                 text = currentAnime.startDate?.let { sdf.format(it) } ?: "Sin fecha",
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = if (currentAnime.startDate != null)
                                                     MaterialTheme.colorScheme.onSurface
@@ -1118,25 +1120,25 @@ fun AnimeDetailScreenLocal(
                                         if (currentAnime.startDate != null) {
                                             IconButton(
                                                 onClick = { viewModel.updateDates(null, currentAnime.endDate) },
-                                                modifier = Modifier.size(32.dp)
+                                                modifier = Modifier.size(32.adp())
                                             ) {
                                                 Icon(
                                                     imageVector = Icons.Default.Clear,
                                                     contentDescription = "Borrar fecha de inicio",
                                                     tint = MaterialTheme.colorScheme.error,
-                                                    modifier = Modifier.size(16.dp)
+                                                    modifier = Modifier.size(16.adp())
                                                 )
                                             }
                                         }
                                         IconButton(
                                             onClick = { showStartDatePicker = true },
-                                            modifier = Modifier.size(32.dp)
+                                            modifier = Modifier.size(32.adp())
                                         ) {
                                             Icon(
                                                 imageVector = Icons.Default.Edit,
                                                 contentDescription = "Editar fecha de inicio",
                                                 tint = MaterialTheme.colorScheme.primary,
-                                                modifier = Modifier.size(16.dp)
+                                                modifier = Modifier.size(16.adp())
                                             )
                                         }
                                     }
@@ -1161,18 +1163,18 @@ fun AnimeDetailScreenLocal(
                                             imageVector = Icons.Default.CalendarToday,
                                             contentDescription = null,
                                             tint = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(18.dp)
+                                            modifier = Modifier.size(18.adp())
                                         )
                                         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                                             Text(
                                                 text = "Finalización",
-                                                fontSize = 12.sp,
+                                                fontSize = 12.asp(),
                                                 fontFamily = PoppinsRegular,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                                             )
                                             Text(
                                                 text = currentAnime.endDate?.let { sdf.format(it) } ?: "Sin fecha",
-                                                fontSize = 14.sp,
+                                                fontSize = 14.asp(),
                                                 fontFamily = PoppinsBold,
                                                 color = if (currentAnime.endDate != null)
                                                     MaterialTheme.colorScheme.onSurface
@@ -1185,25 +1187,25 @@ fun AnimeDetailScreenLocal(
                                         if (currentAnime.endDate != null) {
                                             IconButton(
                                                 onClick = { viewModel.updateDates(currentAnime.startDate, null) },
-                                                modifier = Modifier.size(32.dp)
+                                                modifier = Modifier.size(32.adp())
                                             ) {
                                                 Icon(
                                                     imageVector = Icons.Default.Clear,
                                                     contentDescription = "Borrar fecha de finalización",
                                                     tint = MaterialTheme.colorScheme.error,
-                                                    modifier = Modifier.size(16.dp)
+                                                    modifier = Modifier.size(16.adp())
                                                 )
                                             }
                                         }
                                         IconButton(
                                             onClick = { showEndDatePicker = true },
-                                            modifier = Modifier.size(32.dp)
+                                            modifier = Modifier.size(32.adp())
                                         ) {
                                             Icon(
                                                 imageVector = Icons.Default.Edit,
                                                 contentDescription = "Editar fecha de finalización",
                                                 tint = MaterialTheme.colorScheme.primary,
-                                                modifier = Modifier.size(16.dp)
+                                                modifier = Modifier.size(16.adp())
                                             )
                                         }
                                     }
@@ -1239,20 +1241,20 @@ fun AnimeDetailScreenLocal(
                                     ) {
                                         Text(
                                             text = "Mi Reseña",
-                                            fontSize = 16.sp,
+                                            fontSize = 16.asp(),
                                             fontFamily = PoppinsBold,
                                             color = MaterialTheme.colorScheme.onSurface
                                         )
 
                                         IconButton(
                                             onClick = { /* TODO: Editar reseña */ },
-                                            modifier = Modifier.size(32.dp)
+                                            modifier = Modifier.size(32.adp())
                                         ) {
                                             Icon(
                                                 imageVector = Icons.Default.Edit,
                                                 contentDescription = "Editar reseña",
                                                 tint = MaterialTheme.colorScheme.primary,
-                                                modifier = Modifier.size(18.dp)
+                                                modifier = Modifier.size(18.adp())
                                             )
                                         }
                                     }
@@ -1260,10 +1262,10 @@ fun AnimeDetailScreenLocal(
                                     Text(
                                         text = currentAnime.userOpiniun,
                                         textAlign = TextAlign.Justify,
-                                        fontSize = 14.sp,
+                                        fontSize = 14.asp(),
                                         fontFamily = PoppinsRegular,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        lineHeight = 20.sp
+                                        lineHeight = 20.asp()
                                     )
                                 }
                             }
@@ -1349,17 +1351,17 @@ fun AnimeDetailScreenLocal(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.Center
                         ) {
-                            Icon(Icons.Default.Favorite, null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(24.dp))
+                            Icon(Icons.Default.Favorite, null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(24.adp()))
                             Spacer(modifier = Modifier.width(12.dp))
-                            Text("Editar en mi lista", fontSize = 20.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                            Text("Editar en mi lista", fontSize = 20.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                         }
 
                         // Estado
                         Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Text("Estado", fontSize = 16.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                            Text("Estado", fontSize = 16.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                             LazyVerticalGrid(
                                 columns = GridCells.Fixed(2),
-                                modifier = Modifier.height(180.dp),
+                                modifier = Modifier.height(180.adp()),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
@@ -1367,7 +1369,7 @@ fun AnimeDetailScreenLocal(
                                     val isSelected = sheetStatus == status
                                     Surface(
                                         onClick = { sheetStatus = if (isSelected) null else status },
-                                        modifier = Modifier.height(50.dp),
+                                        modifier = Modifier.height(50.adp()),
                                         shape = RoundedCornerShape(12.dp),
                                         color = if (isSelected) statusColors[status] ?: MaterialTheme.colorScheme.primaryContainer
                                                 else MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -1375,8 +1377,8 @@ fun AnimeDetailScreenLocal(
                                     ) {
                                         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                                             Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
-                                                if (isSelected) Icon(Icons.Default.CheckCircle, null, modifier = Modifier.size(16.dp), tint = Color.Black)
-                                                Text(status, fontSize = 14.sp, fontFamily = PoppinsRegular,
+                                                if (isSelected) Icon(Icons.Default.CheckCircle, null, modifier = Modifier.size(16.adp()), tint = Color.Black)
+                                                Text(status, fontSize = 14.asp(), fontFamily = PoppinsRegular,
                                                     fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                                                     color = if (isSelected) Color.Black else MaterialTheme.colorScheme.onSurface)
                                             }
@@ -1389,7 +1391,7 @@ fun AnimeDetailScreenLocal(
                         // Prioridad + nota (solo si Planeado)
                         AnimatedVisibility(visible = sheetStatus == "Planeado", enter = fadeIn() + expandVertically(), exit = fadeOut() + shrinkVertically()) {
                             Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                Text("Prioridad", fontSize = 16.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                                Text("Prioridad", fontSize = 16.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                                 val priorities = listOf("Alta", "Media", "Baja")
                                 val priorityColors = mapOf("Alta" to Color(0xFFEF5350), "Media" to Color(0xFFFFCA28), "Baja" to Color(0xFF66BB6A))
                                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -1397,25 +1399,25 @@ fun AnimeDetailScreenLocal(
                                         val isSel = sheetPlannedPriority == p
                                         Surface(
                                             onClick = { sheetPlannedPriority = if (isSel) null else p },
-                                            modifier = Modifier.weight(1f).height(44.dp),
+                                            modifier = Modifier.weight(1f).height(44.adp()),
                                             shape = RoundedCornerShape(12.dp),
                                             color = if (isSel) priorityColors[p] ?: MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainerHighest,
                                             shadowElevation = if (isSel) 4.dp else 1.dp
                                         ) {
                                             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                                Text(p, fontSize = 14.sp, fontFamily = PoppinsRegular,
+                                                Text(p, fontSize = 14.asp(), fontFamily = PoppinsRegular,
                                                     fontWeight = if (isSel) FontWeight.Bold else FontWeight.Normal,
                                                     color = if (isSel) Color.Black else MaterialTheme.colorScheme.onSurface)
                                             }
                                         }
                                     }
                                 }
-                                Text("Nota del plan (opcional)", fontSize = 16.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                                Text("Nota del plan (opcional)", fontSize = 16.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                                 OutlinedTextField(
                                     value = sheetPlannedNote,
                                     onValueChange = { sheetPlannedNote = it },
                                     placeholder = { Text("¿Por qué lo tenés planeado?") },
-                                    modifier = Modifier.fillMaxWidth().height(100.dp),
+                                    modifier = Modifier.fillMaxWidth().height(100.adp()),
                                     colors = OutlinedTextFieldDefaults.colors(
                                         focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                                         unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -1432,12 +1434,12 @@ fun AnimeDetailScreenLocal(
                         AnimatedVisibility(visible = sheetStatus != null && sheetStatus != "Planeado", enter = fadeIn() + expandVertically(), exit = fadeOut() + shrinkVertically()) {
                             Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
-                                    Text("Calificación", fontSize = 16.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                                    Text("Calificación", fontSize = 16.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                                     if (sheetRating > 0) {
                                         Surface(shape = RoundedCornerShape(8.dp), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)) {
                                             Row(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), horizontalArrangement = Arrangement.spacedBy(4.dp), verticalAlignment = Alignment.CenterVertically) {
-                                                Icon(Icons.Default.Star, null, tint = Color(0xFFFFD700), modifier = Modifier.size(16.dp))
-                                                Text(String.format("%.1f", sheetRating), fontSize = 14.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.primary)
+                                                Icon(Icons.Default.Star, null, tint = Color(0xFFFFD700), modifier = Modifier.size(16.adp()))
+                                                Text(String.format("%.1f", sheetRating), fontSize = 14.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.primary)
                                             }
                                         }
                                     }
@@ -1452,12 +1454,12 @@ fun AnimeDetailScreenLocal(
 
                         // Opinión
                         Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Text("Opinión (opcional)", fontSize = 16.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                            Text("Opinión (opcional)", fontSize = 16.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                             OutlinedTextField(
                                 value = sheetOpinion,
                                 onValueChange = { sheetOpinion = it },
                                 placeholder = { Text("Comparte tu opinión...") },
-                                modifier = Modifier.fillMaxWidth().height(120.dp),
+                                modifier = Modifier.fillMaxWidth().height(120.adp()),
                                 colors = OutlinedTextFieldDefaults.colors(
                                     focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                                     unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -1471,7 +1473,7 @@ fun AnimeDetailScreenLocal(
 
                         // Fechas
                         Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Text("Fechas (opcional)", fontSize = 16.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                            Text("Fechas (opcional)", fontSize = 16.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                             val canStart = sheetStatus != "Planeado"
                             val canEnd   = sheetStatus == "Completado"
                             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -1482,9 +1484,9 @@ fun AnimeDetailScreenLocal(
                                     color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = if (canStart) 1f else 0.5f)
                                 ) {
                                     Column(modifier = Modifier.padding(12.dp), horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                                        Icon(Icons.Default.CalendarToday, null, modifier = Modifier.size(18.dp),
+                                        Icon(Icons.Default.CalendarToday, null, modifier = Modifier.size(18.adp()),
                                             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = if (canStart) 1f else 0.4f))
-                                        Text(sheetStartDate?.let { dateFormat.format(it) } ?: "Inicio", fontSize = 12.sp, fontFamily = PoppinsRegular,
+                                        Text(sheetStartDate?.let { dateFormat.format(it) } ?: "Inicio", fontSize = 12.asp(), fontFamily = PoppinsRegular,
                                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = if (canStart) 1f else 0.4f))
                                     }
                                 }
@@ -1495,9 +1497,9 @@ fun AnimeDetailScreenLocal(
                                     color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = if (canEnd) 1f else 0.5f)
                                 ) {
                                     Column(modifier = Modifier.padding(12.dp), horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                                        Icon(Icons.Default.CalendarToday, null, modifier = Modifier.size(18.dp),
+                                        Icon(Icons.Default.CalendarToday, null, modifier = Modifier.size(18.adp()),
                                             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = if (canEnd) 1f else 0.4f))
-                                        Text(sheetEndDate?.let { dateFormat.format(it) } ?: "Final", fontSize = 12.sp, fontFamily = PoppinsRegular,
+                                        Text(sheetEndDate?.let { dateFormat.format(it) } ?: "Final", fontSize = 12.asp(), fontFamily = PoppinsRegular,
                                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = if (canEnd) 1f else 0.4f))
                                     }
                                 }
@@ -1536,16 +1538,16 @@ fun AnimeDetailScreenLocal(
                                 }
                             },
                             enabled = sheetStatus != null,
-                            modifier = Modifier.fillMaxWidth().height(54.dp),
+                            modifier = Modifier.fillMaxWidth().height(54.adp()),
                             shape = RoundedCornerShape(12.dp),
                             colors = ButtonDefaults.buttonColors(
                                 containerColor = MaterialTheme.colorScheme.primary,
                                 disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                             )
                         ) {
-                            Icon(Icons.Default.Check, null, modifier = Modifier.size(20.dp))
+                            Icon(Icons.Default.Check, null, modifier = Modifier.size(20.adp()))
                             Spacer(modifier = Modifier.width(8.dp))
-                            Text("Guardar cambios", fontSize = 16.sp, fontFamily = PoppinsBold)
+                            Text("Guardar cambios", fontSize = 16.asp(), fontFamily = PoppinsBold)
                         }
                         Spacer(modifier = Modifier.height(8.dp))
                     }
@@ -1569,14 +1571,14 @@ private fun CompactInfoRow(
     ) {
         Text(
             text = label,
-            fontSize = 13.sp,
+            fontSize = 13.asp(),
             fontFamily = PoppinsRegular,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(0.5f)
         )
         Text(
             text = value,
-            fontSize = 13.sp,
+            fontSize = 13.asp(),
             fontFamily = PoppinsBold,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(0.5f),

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/my_animes/MyAnimesScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/my_animes/MyAnimesScreen.kt
@@ -126,6 +126,8 @@ import com.yumedev.seijakulist.ui.navigation.AppDestinations
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import kotlinx.coroutines.launch
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun MyAnimeListScreen(
@@ -210,7 +212,7 @@ fun MyAnimeListScreen(
                     Text(
                         text = "¡Tu lista está vacía!",
                         fontFamily = PoppinsBold,
-                        fontSize = 28.sp,
+                        fontSize = 28.asp(),
                         color = MaterialTheme.colorScheme.onSurface,
                         textAlign = TextAlign.Center
                     )
@@ -219,10 +221,10 @@ fun MyAnimeListScreen(
                     Text(
                         text = "Comienza a construir tu colección de animes favoritos. Busca y agrega tus primeros títulos para empezar a llevar el control de lo que ves.",
                         fontFamily = PoppinsRegular,
-                        fontSize = 16.sp,
+                        fontSize = 16.asp(),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                         textAlign = TextAlign.Center,
-                        lineHeight = 24.sp
+                        lineHeight = 24.asp()
                     )
 
                     Spacer(modifier = Modifier.height(8.dp))
@@ -234,7 +236,7 @@ fun MyAnimeListScreen(
                         },
                         modifier = Modifier
                             .fillMaxWidth(0.7f)
-                            .height(56.dp),
+                            .height(56.adp()),
                         shape = RoundedCornerShape(16.dp),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.primary,
@@ -248,13 +250,13 @@ fun MyAnimeListScreen(
                         Icon(
                             imageVector = Icons.Default.Search,
                             contentDescription = null,
-                            modifier = Modifier.size(24.dp)
+                            modifier = Modifier.size(24.adp())
                         )
                         Spacer(modifier = Modifier.width(12.dp))
                         Text(
                             text = "Buscar anime",
                             fontFamily = PoppinsBold,
-                            fontSize = 18.sp
+                            fontSize = 18.asp()
                         )
                     }
 
@@ -262,7 +264,7 @@ fun MyAnimeListScreen(
                     Text(
                         text = "Explora miles de títulos disponibles",
                         fontFamily = PoppinsRegular,
-                        fontSize = 14.sp,
+                        fontSize = 14.asp(),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                         textAlign = TextAlign.Center
                     )
@@ -349,14 +351,14 @@ fun MyAnimeListScreen(
                             Text(
                                 text = filter,
                                 fontFamily = if (isSelected) PoppinsBold else PoppinsRegular,
-                                fontSize = 14.sp
+                                fontSize = 14.asp()
                             )
                         },
                         leadingIcon = {
                             Icon(
                                 imageVector = filterIcon,
                                 contentDescription = null,
-                                modifier = Modifier.size(18.dp)
+                                modifier = Modifier.size(18.adp())
                             )
                         },
                         colors = FilterChipDefaults.filterChipColors(
@@ -492,7 +494,7 @@ fun MyAnimeListScreen(
                             ElevatedCard(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(160.dp)
+                                    .height(160.adp())
                                     .graphicsLayer {
                                         scaleX = scale
                                         scaleY = scale
@@ -525,7 +527,7 @@ fun MyAnimeListScreen(
                                         // Imagen
                                         Box(
                                             modifier = Modifier
-                                                .width(120.dp)
+                                                .width(120.adp())
                                                 .fillMaxHeight()
                                         ) {
                                             Image(
@@ -578,7 +580,7 @@ fun MyAnimeListScreen(
                                                                     anime.userScore
                                                                 ),
                                                                 color = Color.White,
-                                                                fontSize = 11.sp,
+                                                                fontSize = 11.asp(),
                                                                 fontFamily = PoppinsBold
                                                             )
                                                         }
@@ -608,11 +610,11 @@ fun MyAnimeListScreen(
                                                 Text(
                                                     text = anime.title,
                                                     fontFamily = PoppinsBold,
-                                                    fontSize = 15.sp,
+                                                    fontSize = 15.asp(),
                                                     color = MaterialTheme.colorScheme.onSurface,
                                                     maxLines = 2,
                                                     overflow = TextOverflow.Ellipsis,
-                                                    lineHeight = 17.sp
+                                                    lineHeight = 17.asp()
                                                 )
 
                                                 // Información adicional (tipo y año si existen)
@@ -627,7 +629,7 @@ fun MyAnimeListScreen(
                                                             Text(
                                                                 text = anime.typeAnime ?: "",
                                                                 fontFamily = PoppinsRegular,
-                                                                fontSize = 11.sp,
+                                                                fontSize = 11.asp(),
                                                                 color = MaterialTheme.colorScheme.onSurface.copy(
                                                                     alpha = 0.6f
                                                                 )
@@ -637,7 +639,7 @@ fun MyAnimeListScreen(
                                                             Text(
                                                                 text = "•",
                                                                 fontFamily = PoppinsRegular,
-                                                                fontSize = 11.sp,
+                                                                fontSize = 11.asp(),
                                                                 color = MaterialTheme.colorScheme.onSurface.copy(
                                                                     alpha = 0.4f
                                                                 )
@@ -647,7 +649,7 @@ fun MyAnimeListScreen(
                                                             Text(
                                                                 text = anime.year ?: "",
                                                                 fontFamily = PoppinsRegular,
-                                                                fontSize = 11.sp,
+                                                                fontSize = 11.asp(),
                                                                 color = MaterialTheme.colorScheme.onSurface.copy(
                                                                     alpha = 0.6f
                                                                 )
@@ -670,13 +672,13 @@ fun MyAnimeListScreen(
                                                     Text(
                                                         text = "${anime.episodesWatched}/${anime.totalEpisodes}",
                                                         fontFamily = PoppinsBold,
-                                                        fontSize = 12.sp,
+                                                        fontSize = 12.asp(),
                                                         color = MaterialTheme.colorScheme.onSurface
                                                     )
                                                     Text(
                                                         text = "eps",
                                                         fontFamily = PoppinsRegular,
-                                                        fontSize = 11.sp,
+                                                        fontSize = 11.asp(),
                                                         color = MaterialTheme.colorScheme.onSurface.copy(
                                                             alpha = 0.6f
                                                         )
@@ -773,7 +775,7 @@ fun MyAnimeListScreen(
                                                                     text = anime.plannedPriority
                                                                         ?: "",
                                                                     fontFamily = PoppinsBold,
-                                                                    fontSize = 10.sp,
+                                                                    fontSize = 10.asp(),
                                                                     color = Color.White
                                                                 )
                                                             }
@@ -794,7 +796,7 @@ fun MyAnimeListScreen(
                                                         },
                                                         shape = RoundedCornerShape(10.dp),
                                                         color = MaterialTheme.colorScheme.primaryContainer,
-                                                        modifier = Modifier.size(32.dp)
+                                                        modifier = Modifier.size(32.adp())
                                                     ) {
                                                         Box(
                                                             modifier = Modifier.fillMaxSize(),
@@ -803,7 +805,7 @@ fun MyAnimeListScreen(
                                                             Icon(
                                                                 imageVector = Icons.Default.PlusOne,
                                                                 contentDescription = "Marcar episodio",
-                                                                modifier = Modifier.size(18.dp),
+                                                                modifier = Modifier.size(18.adp()),
                                                                 tint = MaterialTheme.colorScheme.onPrimaryContainer
                                                             )
                                                         }
@@ -853,7 +855,7 @@ fun MyAnimeListScreen(
                         }
 
                         item {
-                            Spacer(Modifier.height(100.dp))
+                            Spacer(Modifier.height(100.adp()))
                         }
                     }
                 }
@@ -891,7 +893,7 @@ fun CompactAnimeCard(
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
-            .height(220.dp)
+            .height(220.adp())
             .graphicsLayer {
                 scaleX = scale
                 scaleY = scale
@@ -921,7 +923,7 @@ fun CompactAnimeCard(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(160.dp)
+                        .height(160.adp())
                 ) {
                     Image(
                         painter = rememberAsyncImagePainter(anime.imageUrl),
@@ -954,7 +956,7 @@ fun CompactAnimeCard(
                             Text(
                                 text = String.format("%.1f", anime.userScore),
                                 color = Color.White,
-                                fontSize = 11.sp,
+                                fontSize = 11.asp(),
                                 fontFamily = PoppinsBold
                             )
                         }
@@ -972,11 +974,11 @@ fun CompactAnimeCard(
                     Text(
                         text = anime.title,
                         fontFamily = PoppinsBold,
-                        fontSize = 12.sp,
+                        fontSize = 12.asp(),
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
-                        lineHeight = 14.sp
+                        lineHeight = 14.asp()
                     )
 
                     // Progreso
@@ -988,7 +990,7 @@ fun CompactAnimeCard(
                         Text(
                             text = "${anime.episodesWatched}/${anime.totalEpisodes}",
                             fontFamily = PoppinsRegular,
-                            fontSize = 10.sp,
+                            fontSize = 10.asp(),
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                         )
 
@@ -1051,7 +1053,7 @@ fun OnboardingStyleAnimeCard(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .height(260.dp)
+            .height(260.adp())
             .graphicsLayer {
                 scaleX = scale
                 scaleY = scale
@@ -1102,7 +1104,7 @@ fun OnboardingStyleAnimeCard(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(60.dp)
+                    .height(60.adp())
                     .align(Alignment.TopStart)
                     .graphicsLayer {
                         rotationZ = -45f
@@ -1141,7 +1143,7 @@ fun OnboardingStyleAnimeCard(
                                 Text(
                                     text = anime.typeAnime ?: "",
                                     fontFamily = PoppinsBold,
-                                    fontSize = 9.sp,
+                                    fontSize = 9.asp(),
                                     color = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp)
                                 )
@@ -1170,7 +1172,7 @@ fun OnboardingStyleAnimeCard(
                                 Text(
                                     text = String.format("%.1f", anime.userScore),
                                     fontFamily = PoppinsBold,
-                                    fontSize = 11.sp,
+                                    fontSize = 11.asp(),
                                     color = Color.White
                                 )
                             }
@@ -1185,11 +1187,11 @@ fun OnboardingStyleAnimeCard(
                     Text(
                         text = anime.title,
                         fontFamily = PoppinsBold,
-                        fontSize = 15.sp,
+                        fontSize = 15.asp(),
                         color = Color.White,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
-                        lineHeight = 17.sp
+                        lineHeight = 17.asp()
                     )
 
                     // Año si existe
@@ -1197,7 +1199,7 @@ fun OnboardingStyleAnimeCard(
                         Text(
                             text = anime.year ?: "",
                             fontFamily = PoppinsRegular,
-                            fontSize = 11.sp,
+                            fontSize = 11.asp(),
                             color = Color.White.copy(alpha = 0.7f)
                         )
                     }
@@ -1226,7 +1228,7 @@ fun OnboardingStyleAnimeCard(
                                 Text(
                                     text = anime.statusUser,
                                     fontFamily = PoppinsBold,
-                                    fontSize = 11.sp,
+                                    fontSize = 11.asp(),
                                     color = Color.White
                                 )
                             }
@@ -1256,7 +1258,7 @@ fun OnboardingStyleAnimeCard(
                                     Text(
                                         text = anime.plannedPriority ?: "",
                                         fontFamily = PoppinsBold,
-                                        fontSize = 10.sp,
+                                        fontSize = 10.asp(),
                                         color = Color.White
                                     )
                                 }
@@ -1267,7 +1269,7 @@ fun OnboardingStyleAnimeCard(
                         Text(
                             text = "${anime.episodesWatched}/${anime.totalEpisodes}",
                             fontFamily = PoppinsRegular,
-                            fontSize = 10.sp,
+                            fontSize = 10.asp(),
                             color = Color.White.copy(alpha = 0.7f)
                         )
                     }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/novedades/NovedadesScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/novedades/NovedadesScreen.kt
@@ -55,6 +55,8 @@ import com.yumedev.seijakulist.ui.components.WhatsNewVersion
 import com.yumedev.seijakulist.ui.components.WHATS_NEW_HISTORY
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun NovedadesScreen() {
@@ -76,7 +78,7 @@ fun NovedadesScreen() {
             }
         }
 
-        item { Spacer(modifier = Modifier.height(96.dp)) }
+        item { Spacer(modifier = Modifier.height(96.adp())) }
     }
 }
 
@@ -118,7 +120,7 @@ private fun VersionSection(
                     Text(
                         text = "v${version.versionName}",
                         fontFamily = PoppinsBold,
-                        fontSize = 18.sp,
+                        fontSize = 18.asp(),
                         color = MaterialTheme.colorScheme.onSurface
                     )
                     if (isLatest) {
@@ -131,7 +133,7 @@ private fun VersionSection(
                             Text(
                                 text = "Actual",
                                 fontFamily = PoppinsBold,
-                                fontSize = 10.sp,
+                                fontSize = 10.asp(),
                                 color = MaterialTheme.colorScheme.onPrimary
                             )
                         }
@@ -143,7 +145,7 @@ private fun VersionSection(
                     Text(
                         text = "${version.changes.size} cambios",
                         fontFamily = PoppinsRegular,
-                        fontSize = 12.sp,
+                        fontSize = 12.asp(),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
                     )
                 }
@@ -155,7 +157,7 @@ private fun VersionSection(
                 contentDescription = if (expanded) "Colapsar" else "Expandir",
                 tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
                 modifier = Modifier
-                    .size(22.dp)
+                    .size(22.adp())
                     .rotate(arrowRotation)
             )
         }
@@ -206,7 +208,7 @@ private fun ChangeItem(change: WhatsNewChange) {
         ) {
             Box(
                 modifier = Modifier
-                    .size(36.dp)
+                    .size(36.adp())
                     .clip(CircleShape)
                     .background(style.color.copy(alpha = 0.13f)),
                 contentAlignment = Alignment.Center
@@ -215,7 +217,7 @@ private fun ChangeItem(change: WhatsNewChange) {
                     imageVector = style.icon,
                     contentDescription = null,
                     tint = style.color,
-                    modifier = Modifier.size(19.dp)
+                    modifier = Modifier.size(19.adp())
                 )
             }
 
@@ -226,22 +228,22 @@ private fun ChangeItem(change: WhatsNewChange) {
                 Text(
                     text = style.label,
                     fontFamily = PoppinsBold,
-                    fontSize = 10.sp,
+                    fontSize = 10.asp(),
                     color = style.color,
                     letterSpacing = 0.6.sp
                 )
                 Text(
                     text = change.title,
                     fontFamily = PoppinsBold,
-                    fontSize = 13.sp,
+                    fontSize = 13.asp(),
                     color = MaterialTheme.colorScheme.onSurface
                 )
                 Text(
                     text = change.description,
                     fontFamily = PoppinsRegular,
-                    fontSize = 12.sp,
+                    fontSize = 12.asp(),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f),
-                    lineHeight = 17.sp
+                    lineHeight = 17.asp()
                 )
             }
         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/policy_privacy/PolicyPrivacyScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/policy_privacy/PolicyPrivacyScreen.kt
@@ -35,6 +35,8 @@ import androidx.navigation.NavController
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsMedium
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun PolicyPrivacyScreen(navController: NavController) {
@@ -185,7 +187,7 @@ fun PolicyPrivacyScreen(navController: NavController) {
                         text = "seijakulist@gmail.com",
                         fontFamily = PoppinsBold,
                         color = MaterialTheme.colorScheme.primary,
-                        fontSize = 16.sp,
+                        fontSize = 16.asp(),
                         modifier = Modifier.clickable {
                             val intent = Intent(Intent.ACTION_SENDTO).apply {
                                 data = Uri.parse("mailto:seijakulist@gmail.com")
@@ -203,14 +205,14 @@ fun PolicyPrivacyScreen(navController: NavController) {
             PolicyTitle("13. Consentimiento")
             PolicyBody("Al usar Seijaku List, usted consiente nuestra Política de Privacidad y acepta sus términos.")
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
             Text(
                 text = "© 2026 Seijaku List. Versión: $versionName",
                 style = MaterialTheme.typography.bodySmall,
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center
             )
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
         }
     }
     }
@@ -250,7 +252,7 @@ fun PolicyBody(text: String) {
         text = text,
         style = MaterialTheme.typography.bodyMedium.copy(
             fontFamily = PoppinsRegular,
-            lineHeight = 22.sp,
+            lineHeight = 22.asp(),
             color = MaterialTheme.colorScheme.onSurfaceVariant
         ),
         modifier = Modifier.padding(bottom = 12.dp),

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/profile/ProfileLoaderScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/profile/ProfileLoaderScreen.kt
@@ -24,6 +24,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.yumedev.seijakulist.ui.navigation.AppDestinations
+import com.yumedev.seijakulist.ui.theme.adp
 
 @Composable
 fun ProfileLoaderScreen(navController: NavController, profileViewModel: ProfileViewModel = hiltViewModel()) {
@@ -69,7 +70,7 @@ fun ProfileLoaderScreen(navController: NavController, profileViewModel: ProfileV
         ) {
             Box(
                 modifier = Modifier
-                    .size(48.dp)
+                    .size(48.adp())
                     .scale(scale)
                     .background(
                         color = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/profile/ProfileSetupView.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/profile/ProfileSetupView.kt
@@ -52,6 +52,8 @@ import com.yumedev.seijakulist.ui.screens.auth_screen.AuthResult
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsMedium
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun ProfileSetupView(
@@ -126,19 +128,19 @@ fun ProfileSetupView(
                 ) {
                     Text(
                         text       = if (isEditMode) "Actualiza tu perfil" else "Crea tu perfil",
-                        fontSize   = 28.sp,
+                        fontSize = 28.asp(),
                         fontFamily = PoppinsBold,
                         color      = MaterialTheme.colorScheme.onBackground
                     )
                     Text(
                         text       = "Cuéntanos un poco sobre ti",
-                        fontSize   = 15.sp,
+                        fontSize = 15.asp(),
                         fontFamily = PoppinsRegular,
                         color      = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(50.dp))
+            Spacer(modifier = Modifier.height(50.adp()))
         }
 
         // ── Avatar ────────────────────────────────────────────────────────────
@@ -152,7 +154,7 @@ fun ProfileSetupView(
                     onImagePick = { launcher.launch("image/*") }
                 )
             }
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
         }
 
         // ── Username ──────────────────────────────────────────────────────────
@@ -167,7 +169,7 @@ fun ProfileSetupView(
                 ) {
                     Text(
                         text       = "Nombre de usuario",
-                        fontSize   = 13.sp,
+                        fontSize = 13.asp(),
                         fontFamily = PoppinsMedium,
                         color      = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                         modifier   = Modifier.padding(start = 4.dp)
@@ -175,7 +177,7 @@ fun ProfileSetupView(
                     OutlinedTextField(
                         value         = username,
                         onValueChange = { username = it },
-                        placeholder   = { Text("Tu nombre", fontFamily = PoppinsRegular, fontSize = 15.sp) },
+                        placeholder   = { Text("Tu nombre", fontFamily = PoppinsRegular, fontSize = 15.asp()) },
                         leadingIcon   = { Icon(Icons.Default.Person, null, tint = MaterialTheme.colorScheme.primary) },
                         modifier      = Modifier.fillMaxWidth(),
                         shape         = RoundedCornerShape(16.dp),
@@ -186,7 +188,7 @@ fun ProfileSetupView(
                             unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                         ),
                         singleLine = true,
-                        textStyle  = LocalTextStyle.current.copy(fontFamily = PoppinsMedium, fontSize = 15.sp)
+                        textStyle  = LocalTextStyle.current.copy(fontFamily = PoppinsMedium, fontSize = 15.asp())
                     )
                 }
             }
@@ -210,14 +212,14 @@ fun ProfileSetupView(
                     ) {
                         Text(
                             text       = "Biografía (opcional)",
-                            fontSize   = 13.sp,
+                            fontSize = 13.asp(),
                             fontFamily = PoppinsMedium,
                             color      = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                             modifier   = Modifier.padding(start = 4.dp)
                         )
                         Text(
                             text       = "${bio.length}/150",
-                            fontSize   = 12.sp,
+                            fontSize = 12.asp(),
                             fontFamily = PoppinsRegular,
                             color      = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
                         )
@@ -225,7 +227,7 @@ fun ProfileSetupView(
                     OutlinedTextField(
                         value         = bio,
                         onValueChange = { if (it.length <= 150) bio = it },
-                        placeholder   = { Text("¿Qué animes te gustan?", fontFamily = PoppinsRegular, fontSize = 15.sp) },
+                        placeholder   = { Text("¿Qué animes te gustan?", fontFamily = PoppinsRegular, fontSize = 15.asp()) },
                         modifier      = Modifier.fillMaxWidth(),
                         shape         = RoundedCornerShape(16.dp),
                         colors        = OutlinedTextFieldDefaults.colors(
@@ -236,11 +238,11 @@ fun ProfileSetupView(
                         ),
                         maxLines  = 3,
                         minLines  = 3,
-                        textStyle = LocalTextStyle.current.copy(fontFamily = PoppinsRegular, fontSize = 14.sp)
+                        textStyle = LocalTextStyle.current.copy(fontFamily = PoppinsRegular, fontSize = 14.asp())
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(40.adp()))
         }
 
         // ── Botón guardar ─────────────────────────────────────────────────────
@@ -253,7 +255,7 @@ fun ProfileSetupView(
                     onClick = { profileViewModel.updateUserProfile(username, bio, selectedImageUri) },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(54.dp)
+                        .height(54.adp())
                         .graphicsLayer { scaleX = buttonScale; scaleY = buttonScale },
                     shape    = RoundedCornerShape(16.dp),
                     enabled  = username.isNotBlank() && !uiState.isLoading,
@@ -264,9 +266,9 @@ fun ProfileSetupView(
                     interactionSource = interactionSource
                 ) {
                     if (uiState.isLoading) {
-                        CircularProgressIndicator(modifier = Modifier.size(22.dp), color = MaterialTheme.colorScheme.onPrimary, strokeWidth = 2.5.dp)
+                        CircularProgressIndicator(modifier = Modifier.size(22.adp()), color = MaterialTheme.colorScheme.onPrimary, strokeWidth = 2.5.dp)
                     } else {
-                        Text(if (isEditMode) "Actualizar" else "Continuar", fontSize = 16.sp, fontFamily = PoppinsBold)
+                        Text(if (isEditMode) "Actualizar" else "Continuar", fontSize = 16.asp(), fontFamily = PoppinsBold)
                     }
                 }
             }
@@ -277,7 +279,7 @@ fun ProfileSetupView(
             AnimatedVisibility(visible = uiState.isLoading) {
                 Text(
                     text       = if (uiState.isUploadingImage) "Subiendo imagen..." else "Guardando...",
-                    fontSize   = 13.sp,
+                    fontSize = 13.asp(),
                     color      = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                     fontFamily = PoppinsRegular,
                     modifier   = Modifier.padding(top = 16.dp)
@@ -292,7 +294,7 @@ fun ProfileSetupView(
                     Text(
                         text       = uiState.error ?: "",
                         color      = MaterialTheme.colorScheme.error,
-                        fontSize   = 13.sp,
+                        fontSize = 13.asp(),
                         modifier   = Modifier.padding(16.dp),
                         textAlign  = TextAlign.Center,
                         fontFamily = PoppinsRegular
@@ -322,12 +324,12 @@ private fun ProfileImagePicker(
 
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.size(140.dp)
+        modifier = Modifier.size(140.adp())
     ) {
         // Círculo decorativo de fondo
         Box(
             modifier = Modifier
-                .size(150.dp)
+                .size(150.adp())
                 .background(
                     brush = Brush.radialGradient(
                         colors = listOf(
@@ -342,7 +344,7 @@ private fun ProfileImagePicker(
         // Imagen principal
         Surface(
             modifier = Modifier
-                .size(140.dp)
+                .size(140.adp())
                 .graphicsLayer {
                     scaleX = scale
                     scaleY = scale
@@ -374,7 +376,7 @@ private fun ProfileImagePicker(
                     Icon(
                         imageVector = Icons.Default.AccountCircle,
                         contentDescription = "Agregar foto",
-                        modifier = Modifier.size(80.dp),
+                        modifier = Modifier.size(80.adp()),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
                     )
                 }
@@ -384,7 +386,7 @@ private fun ProfileImagePicker(
         // Botón de editar
         Surface(
             modifier = Modifier
-                .size(42.dp)
+                .size(42.adp())
                 .align(Alignment.BottomEnd)
                 .offset(x = (-4).dp, y = (-4).dp)
                 .clickable(onClick = onImagePick),
@@ -400,7 +402,7 @@ private fun ProfileImagePicker(
                     imageVector = Icons.Default.Edit,
                     contentDescription = "Cambiar foto",
                     tint = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(20.adp())
                 )
             }
         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/profile/ProfileView.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/profile/ProfileView.kt
@@ -59,6 +59,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import kotlinx.coroutines.delay
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 // ─────────────────────────────────────────────────────────────────────────────
 //  Datos de logros
@@ -94,10 +96,10 @@ private fun EmptyProfileScreen(navController: NavController) {
                 visible = screenVisible,
                 enter = fadeIn(tween(600)) + scaleIn(initialScale = 0.9f, animationSpec = tween(600))
             ) {
-                Box(contentAlignment = Alignment.Center, modifier = Modifier.size(120.dp)) {
+                Box(contentAlignment = Alignment.Center, modifier = Modifier.size(120.adp())) {
                     Box(
                         modifier = Modifier
-                            .size(130.dp)
+                            .size(130.adp())
                             .background(
                                 brush = Brush.radialGradient(
                                     colors = listOf(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), Color.Transparent)
@@ -108,7 +110,7 @@ private fun EmptyProfileScreen(navController: NavController) {
                     Icon(
                         Icons.Default.AccountCircle,
                         contentDescription = null,
-                        modifier = Modifier.size(100.dp),
+                        modifier = Modifier.size(100.adp()),
                         tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
                     )
                 }
@@ -121,7 +123,7 @@ private fun EmptyProfileScreen(navController: NavController) {
                 ) {
                     Text(
                         "Crea tu cuenta",
-                        fontSize = 26.sp,
+                        fontSize = 26.asp(),
                         fontFamily = PoppinsBold,
                         color = MaterialTheme.colorScheme.onBackground
                     )
@@ -131,18 +133,18 @@ private fun EmptyProfileScreen(navController: NavController) {
                     ) {
                         Text(
                             "Sincroniza tus animes en la nube",
-                            fontSize = 14.sp,
+                            fontSize = 14.asp(),
                             fontFamily = PoppinsRegular,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
                             textAlign = TextAlign.Center
                         )
                         Text(
                             "Cambia de celular sin perder nada, desbloquea logros y accede a todas las características de Seijaku List",
-                            fontSize = 13.sp,
+                            fontSize = 13.asp(),
                             fontFamily = PoppinsRegular,
                             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                             textAlign = TextAlign.Center,
-                            lineHeight = 18.sp,
+                            lineHeight = 18.asp(),
                             modifier = Modifier.padding(horizontal = 8.dp)
                         )
                     }
@@ -158,14 +160,14 @@ private fun EmptyProfileScreen(navController: NavController) {
             ) {
                 Button(
                     onClick = { navController.navigate(AppDestinations.AUTH_ROUTE) },
-                    modifier = Modifier.fillMaxWidth().height(54.dp),
+                    modifier = Modifier.fillMaxWidth().height(54.adp()),
                     shape = RoundedCornerShape(16.dp),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) {
-                    Text("Comenzar", fontSize = 16.sp, fontFamily = PoppinsBold)
+                    Text("Comenzar", fontSize = 16.asp(), fontFamily = PoppinsBold)
                 }
             }
-            Spacer(modifier = Modifier.height(100.dp))
+            Spacer(modifier = Modifier.height(100.adp()))
         }
     }
 }
@@ -294,13 +296,13 @@ fun ProfileView(
                             ) {
                                 IconButton(
                                     onClick   = { navController.navigate(AppDestinations.SELECT_TOP5_ROUTE) },
-                                    modifier  = Modifier.size(36.dp)
+                                    modifier  = Modifier.size(36.adp())
                                 ) {
                                     Icon(
                                         Icons.Default.Edit,
                                         contentDescription = "Editar Top 5",
                                         tint     = MaterialTheme.colorScheme.primary,
-                                        modifier = Modifier.size(20.dp)
+                                        modifier = Modifier.size(20.adp())
                                     )
                                 }
                             }
@@ -322,19 +324,19 @@ fun ProfileView(
                                         Icon(
                                             Icons.Default.Star,
                                             contentDescription = null,
-                                            modifier = Modifier.size(48.dp),
+                                            modifier = Modifier.size(48.adp()),
                                             tint     = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
                                         )
                                         Text(
                                             "Seleccioná tus 5 animes favoritos",
-                                            fontSize   = 16.sp,
+                                            fontSize = 16.asp(),
                                             fontFamily = PoppinsRegular,
                                             color      = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                                         )
                                         FilledTonalButton(
                                             onClick = { navController.navigate(AppDestinations.SELECT_TOP5_ROUTE) }
                                         ) {
-                                            Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                                            Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.adp()))
                                             Spacer(modifier = Modifier.width(8.dp))
                                             Text("Elegir Top 5", fontFamily = PoppinsBold)
                                         }
@@ -351,18 +353,18 @@ fun ProfileView(
                             Icon(
                                 Icons.AutoMirrored.Filled.MenuBook,
                                 contentDescription = null,
-                                modifier = Modifier.size(64.dp),
+                                modifier = Modifier.size(64.adp()),
                                 tint     = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
                             )
                             Text(
                                 "¡Manga en camino!",
-                                fontSize   = 20.sp,
+                                fontSize = 20.asp(),
                                 fontFamily = PoppinsBold,
                                 color      = MaterialTheme.colorScheme.onBackground
                             )
                             Text(
                                 "Estamos trabajando para que puedas trackear tus lecturas muy pronto.",
-                                fontSize   = 14.sp,
+                                fontSize = 14.asp(),
                                 fontFamily = PoppinsRegular,
                                 color      = MaterialTheme.colorScheme.onSurfaceVariant,
                                 textAlign  = TextAlign.Center
@@ -373,7 +375,7 @@ fun ProfileView(
             }
         }
 
-        item { Spacer(modifier = Modifier.height(90.dp)) }
+        item { Spacer(modifier = Modifier.height(90.adp())) }
     }
 }
 
@@ -400,7 +402,7 @@ private fun ProfileHeader(
         ) {
             // Avatar
             Surface(
-                modifier        = Modifier.size(68.dp),
+                modifier        = Modifier.size(68.adp()),
                 shape           = CircleShape,
                 border          = BorderStroke(1.5.dp, MaterialTheme.colorScheme.outlineVariant),
                 shadowElevation = 4.dp
@@ -420,7 +422,7 @@ private fun ProfileHeader(
                         Icon(
                             Icons.Default.Person,
                             contentDescription = null,
-                            modifier = Modifier.size(36.dp),
+                            modifier = Modifier.size(36.adp()),
                             tint     = MaterialTheme.colorScheme.onPrimaryContainer
                         )
                     }
@@ -434,7 +436,7 @@ private fun ProfileHeader(
             ) {
                 Text(
                     text          = username,
-                    fontSize      = 18.sp,
+                    fontSize = 18.asp(),
                     fontFamily    = PoppinsBold,
                     letterSpacing = (-0.3).sp,
                     color         = MaterialTheme.colorScheme.onBackground,
@@ -444,12 +446,12 @@ private fun ProfileHeader(
                 if (userBio.isNotBlank()) {
                     Text(
                         text       = userBio,
-                        fontSize   = 12.sp,
+                        fontSize = 12.asp(),
                         fontFamily = PoppinsRegular,
                         color      = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines   = 2,
                         overflow   = TextOverflow.Ellipsis,
-                        lineHeight = 16.sp
+                        lineHeight = 16.asp()
                     )
                 }
             }
@@ -462,7 +464,7 @@ private fun ProfileHeader(
                 shape          = RoundedCornerShape(10.dp),
                 border         = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
             ) {
-                Text("Editar", fontSize = 12.sp, fontFamily = PoppinsMedium)
+                Text("Editar", fontSize = 12.asp(), fontFamily = PoppinsMedium)
             }
         }
 
@@ -549,13 +551,13 @@ private fun ProfileStatsSection(
                 ) {
                     Text(
                         "$completedAnimes de $totalAnimes completados",
-                        fontSize   = 11.sp,
+                        fontSize = 11.asp(),
                         fontFamily = PoppinsMedium,
                         color      = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     Text(
                         "$completionPct%",
-                        fontSize   = 11.sp,
+                        fontSize = 11.asp(),
                         fontFamily = PoppinsBold,
                         color      = MaterialTheme.colorScheme.primary
                     )
@@ -602,7 +604,7 @@ private fun StatCard(
         ) {
             Text(
                 text          = value,
-                fontSize      = 20.sp,
+                fontSize = 20.asp(),
                 fontFamily    = PoppinsBold,
                 color         = MaterialTheme.colorScheme.onBackground,
                 letterSpacing = (-0.5).sp,
@@ -610,7 +612,7 @@ private fun StatCard(
             )
             Text(
                 text       = label,
-                fontSize   = 11.sp,
+                fontSize = 11.asp(),
                 fontFamily = PoppinsRegular,
                 color      = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines   = 1
@@ -637,14 +639,14 @@ private fun StatusCard(label: String, count: Int, color: Color, modifier: Modifi
         ) {
             Text(
                 text       = label,
-                fontSize   = 13.sp,
+                fontSize = 13.asp(),
                 fontFamily = PoppinsMedium,
                 color      = MaterialTheme.colorScheme.onSurface,
                 maxLines   = 1
             )
             Text(
                 text       = "$count",
-                fontSize   = 22.sp,
+                fontSize = 22.asp(),
                 fontFamily = PoppinsBold,
                 color      = color,
                 maxLines   = 1
@@ -682,7 +684,7 @@ fun MinimalTabRow(
             Box(
                 modifier = Modifier
                     .weight(1f)
-                    .height(40.dp)
+                    .height(40.adp())
                     .background(
                         color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f * bgAlpha),
                         shape = RoundedCornerShape(10.dp)
@@ -695,7 +697,7 @@ fun MinimalTabRow(
             ) {
                 Text(
                     text       = title,
-                    fontSize   = 14.sp,
+                    fontSize = 14.asp(),
                     fontFamily = if (isSelected) PoppinsBold else PoppinsMedium,
                     color      = if (isSelected)
                         MaterialTheme.colorScheme.primary
@@ -717,7 +719,7 @@ fun CustomSeijakuTabSelector(tabs: List<String>, selectedTabIndex: Int, onTabSel
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp, vertical = 8.dp)
-            .height(48.dp),
+            .height(48.adp()),
         shape  = CircleShape,
         color  = MaterialTheme.colorScheme.surfaceContainer,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.1f))
@@ -752,7 +754,7 @@ fun CustomSeijakuTabSelector(tabs: List<String>, selectedTabIndex: Int, onTabSel
                         Text(
                             title,
                             fontFamily = PoppinsBold,
-                            fontSize   = 14.sp,
+                            fontSize = 14.asp(),
                             color      = if (selectedTabIndex == index)
                                 MaterialTheme.colorScheme.onPrimary
                             else
@@ -779,7 +781,7 @@ private fun GenreFavoriteCard(
 ) {
     val percentage = if (totalCount > 0) ((count.toFloat() / totalCount) * 100).toInt() else 0
     ElevatedCard(
-        modifier  = modifier.height(110.dp),
+        modifier  = modifier.height(110.adp()),
         shape     = RoundedCornerShape(12.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors    = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
@@ -804,7 +806,7 @@ private fun GenreFavoriteCard(
             )
             Text(
                 text     = "$percentage%",
-                fontSize = 11.sp,
+                fontSize = 11.asp(),
                 fontFamily = PoppinsBold,
                 color    = Color.White,
                 modifier = Modifier
@@ -819,7 +821,7 @@ private fun GenreFavoriteCard(
             ) {
                 Text(
                     genre,
-                    fontSize   = 12.sp,
+                    fontSize = 12.asp(),
                     fontFamily = PoppinsBold,
                     color      = Color.White,
                     maxLines   = 1,
@@ -827,7 +829,7 @@ private fun GenreFavoriteCard(
                 )
                 Text(
                     if (count == 1) "$count anime" else "$count animes",
-                    fontSize   = 10.sp,
+                    fontSize = 10.asp(),
                     fontFamily = PoppinsRegular,
                     color      = Color.White.copy(alpha = 0.8f)
                 )
@@ -863,7 +865,7 @@ private fun AnimeTop5Showcase(animes: List<AnimeEntity>, navController: NavContr
     ) {
         Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Row(
-                modifier              = Modifier.fillMaxWidth().height(260.dp),
+                modifier              = Modifier.fillMaxWidth().height(260.adp()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Column(
@@ -918,7 +920,7 @@ private fun AnimeTop5Showcase(animes: List<AnimeEntity>, navController: NavContr
                             ShowcaseCell(
                                 anime         = anime,
                                 position      = 4,
-                                modifier      = Modifier.fillMaxWidth().height(100.dp),
+                                modifier      = Modifier.fillMaxWidth().height(100.adp()),
                                 navController = navController
                             )
                         }
@@ -933,7 +935,7 @@ private fun AnimeTop5Showcase(animes: List<AnimeEntity>, navController: NavContr
                                 ShowcaseCell(
                                     anime         = anime,
                                     position      = 5,
-                                    modifier      = Modifier.fillMaxWidth().height(100.dp),
+                                    modifier      = Modifier.fillMaxWidth().height(100.adp()),
                                     navController = navController
                                 )
                             }
@@ -957,7 +959,7 @@ private fun AnimeTop5Showcase(animes: List<AnimeEntity>, navController: NavContr
                 Spacer(modifier = Modifier.width(3.dp))
                 Text(
                     "SeijakuList",
-                    fontSize      = 9.sp,
+                    fontSize = 9.asp(),
                     fontFamily    = PoppinsBold,
                     color         = MaterialTheme.colorScheme.onSurface.copy(0.22f),
                     letterSpacing = 0.5.sp
@@ -989,7 +991,7 @@ private fun Top5RankLabel(position: Int) {
         }
         Text(
             text          = rankText,
-            fontSize      = 11.sp,
+            fontSize = 11.asp(),
             fontFamily    = PoppinsBold,
             color         = rankColor,
             letterSpacing = if (position == 1) 0.6.sp else 0.sp
@@ -1071,7 +1073,7 @@ private fun ShowcaseCell(
                         verticalAlignment     = Alignment.CenterVertically
                     ) {
                         Icon(Icons.Default.Star, contentDescription = null, tint = Color(0xFFFFD700), modifier = Modifier.size(10.dp))
-                        Text("${anime.userScore}", fontSize = 10.sp, fontFamily = PoppinsBold, color = Color.White)
+                        Text("${anime.userScore}", fontSize = 10.asp(), fontFamily = PoppinsBold, color = Color.White)
                     }
                 }
             }
@@ -1114,10 +1116,10 @@ private fun AllAchievementsDialog(achievements: List<Achievement>, onDismiss: ()
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalAlignment     = Alignment.CenterVertically
                     ) {
-                        Icon(Icons.Default.EmojiEvents, contentDescription = null, tint = Color(0xFFFF9800), modifier = Modifier.size(22.dp))
-                        Text("Todos los logros", fontSize = 18.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                        Icon(Icons.Default.EmojiEvents, contentDescription = null, tint = Color(0xFFFF9800), modifier = Modifier.size(22.adp()))
+                        Text("Todos los logros", fontSize = 18.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                     }
-                    IconButton(onClick = onDismiss, modifier = Modifier.size(32.dp)) {
+                    IconButton(onClick = onDismiss, modifier = Modifier.size(32.adp())) {
                         Icon(Icons.Default.Close, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 }
@@ -1170,13 +1172,13 @@ private fun AchievementCard(achievement: Achievement, onClick: () -> Unit = {}) 
         ) {
             Box(
                 modifier         = Modifier
-                    .size(44.dp)
+                    .size(44.adp())
                     .clip(CircleShape)
                     .background(color.copy(alpha = 0.15f))
                     .border(width = 1.5.dp, color = color, shape = CircleShape),
                 contentAlignment = Alignment.Center
             ) {
-                Icon(imageVector = achievement.icon, contentDescription = null, tint = color, modifier = Modifier.size(22.dp))
+                Icon(imageVector = achievement.icon, contentDescription = null, tint = color, modifier = Modifier.size(22.adp()))
             }
             Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Row(
@@ -1185,7 +1187,7 @@ private fun AchievementCard(achievement: Achievement, onClick: () -> Unit = {}) 
                 ) {
                     Text(
                         achievement.name,
-                        fontSize   = 14.sp,
+                        fontSize = 14.asp(),
                         fontFamily = PoppinsBold,
                         color      = MaterialTheme.colorScheme.onSurface,
                         maxLines   = 1,
@@ -1199,7 +1201,7 @@ private fun AchievementCard(achievement: Achievement, onClick: () -> Unit = {}) 
                     ) {
                         Text(
                             achievement.typeAchievement,
-                            fontSize   = 10.sp,
+                            fontSize = 10.asp(),
                             fontFamily = PoppinsBold,
                             color      = color,
                             modifier   = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
@@ -1208,12 +1210,12 @@ private fun AchievementCard(achievement: Achievement, onClick: () -> Unit = {}) 
                 }
                 Text(
                     achievement.description,
-                    fontSize   = 12.sp,
+                    fontSize = 12.asp(),
                     fontFamily = PoppinsRegular,
                     color      = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines   = 2,
                     overflow   = TextOverflow.Ellipsis,
-                    lineHeight = 16.sp
+                    lineHeight = 16.asp()
                 )
             }
         }
@@ -1241,29 +1243,29 @@ private fun AchievementDetailDialog(achievement: Achievement, onDismiss: () -> U
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.TopEnd) {
-                    IconButton(onClick = onDismiss, modifier = Modifier.size(32.dp)) {
+                    IconButton(onClick = onDismiss, modifier = Modifier.size(32.adp())) {
                         Icon(Icons.Default.Close, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 Box(
                     modifier = Modifier
-                        .size(120.dp)
+                        .size(120.adp())
                         .clip(CircleShape)
                         .background(Brush.radialGradient(colors = listOf(color.copy(alpha = 0.8f), color.copy(alpha = 0.4f))))
                         .border(width = 4.dp, color = color, shape = CircleShape),
                     contentAlignment = Alignment.Center
                 ) {
-                    Icon(imageVector = achievement.icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(56.dp))
+                    Icon(imageVector = achievement.icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(56.adp()))
                 }
                 Spacer(modifier = Modifier.height(24.dp))
                 Surface(shape = RoundedCornerShape(12.dp), color = color.copy(alpha = 0.2f)) {
-                    Text(achievement.typeAchievement, fontSize = 14.sp, fontFamily = PoppinsBold, color = color, modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp))
+                    Text(achievement.typeAchievement, fontSize = 14.asp(), fontFamily = PoppinsBold, color = color, modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp))
                 }
                 Spacer(modifier = Modifier.height(16.dp))
-                Text(achievement.name, fontSize = 24.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface, textAlign = TextAlign.Center)
+                Text(achievement.name, fontSize = 24.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface, textAlign = TextAlign.Center)
                 Spacer(modifier = Modifier.height(12.dp))
-                Text(achievement.description, fontSize = 16.sp, fontFamily = PoppinsRegular, color = MaterialTheme.colorScheme.onSurfaceVariant, textAlign = TextAlign.Center, lineHeight = 22.sp)
+                Text(achievement.description, fontSize = 16.asp(), fontFamily = PoppinsRegular, color = MaterialTheme.colorScheme.onSurfaceVariant, textAlign = TextAlign.Center, lineHeight = 22.asp())
                 Spacer(modifier = Modifier.height(24.dp))
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                 Spacer(modifier = Modifier.height(16.dp))
@@ -1274,10 +1276,10 @@ private fun AchievementDetailDialog(achievement: Achievement, onDismiss: () -> U
                         verticalAlignment     = Alignment.CenterVertically
                     ) {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                            Icon(Icons.Default.CalendarToday, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
-                            Text("Desbloqueado", fontSize = 14.sp, fontFamily = PoppinsRegular, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Icon(Icons.Default.CalendarToday, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.adp()))
+                            Text("Desbloqueado", fontSize = 14.asp(), fontFamily = PoppinsRegular, color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
-                        Text(achievement.unlockDate, fontSize = 14.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                        Text(achievement.unlockDate, fontSize = 14.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                     }
                     Row(
                         modifier              = Modifier.fillMaxWidth(),
@@ -1285,15 +1287,15 @@ private fun AchievementDetailDialog(achievement: Achievement, onDismiss: () -> U
                         verticalAlignment     = Alignment.CenterVertically
                     ) {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                            Icon(Icons.Default.EmojiEvents, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
-                            Text("Recompensa", fontSize = 14.sp, fontFamily = PoppinsRegular, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Icon(Icons.Default.EmojiEvents, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.adp()))
+                            Text("Recompensa", fontSize = 14.asp(), fontFamily = PoppinsRegular, color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
-                        Text(achievement.reward, fontSize = 14.sp, fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
+                        Text(achievement.reward, fontSize = 14.asp(), fontFamily = PoppinsBold, color = MaterialTheme.colorScheme.onSurface)
                     }
                 }
                 Spacer(modifier = Modifier.height(24.dp))
                 Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(12.dp)) {
-                    Text("Cerrar", fontFamily = PoppinsBold, fontSize = 16.sp)
+                    Text("Cerrar", fontFamily = PoppinsBold, fontSize = 16.asp())
                 }
             }
         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/profile/SelectTop5Screen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/profile/SelectTop5Screen.kt
@@ -74,6 +74,8 @@ import com.yumedev.seijakulist.ui.components.DialogType
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import kotlinx.coroutines.delay
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 private val top5PositionColors = listOf(
     Color(0xFFFFD700), // #1 Oro
@@ -190,11 +192,11 @@ fun SelectTop5Screen(
                         Text(
                             text = "Mi Top 5",
                             fontFamily = PoppinsBold,
-                            fontSize = 20.sp
+                            fontSize = 20.asp()
                         )
                         Text(
                             text = "${orderedSelectedIds.size}/5 seleccionados",
-                            fontSize = 12.sp,
+                            fontSize = 12.asp(),
                             fontFamily = PoppinsRegular,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                         )
@@ -218,7 +220,7 @@ fun SelectTop5Screen(
                     ) {
                         if (uiState.isSavingTop5) {
                             CircularProgressIndicator(
-                                modifier = Modifier.size(16.dp),
+                                modifier = Modifier.size(16.adp()),
                                 strokeWidth = 2.dp,
                                 color = MaterialTheme.colorScheme.primary
                             )
@@ -226,7 +228,7 @@ fun SelectTop5Screen(
                             Icon(
                                 imageVector = Icons.Default.Check,
                                 contentDescription = null,
-                                modifier = Modifier.size(18.dp)
+                                modifier = Modifier.size(18.adp())
                             )
                             Spacer(modifier = Modifier.width(4.dp))
                             Text("Guardar", fontFamily = PoppinsBold)
@@ -279,7 +281,7 @@ fun SelectTop5Screen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 2.dp),
-                fontSize = 12.sp,
+                fontSize = 12.asp(),
                 fontFamily = PoppinsRegular,
                 textAlign = TextAlign.Center,
                 color = if (activeSlotIndex != null)
@@ -339,18 +341,18 @@ fun SelectTop5Screen(
                             Icon(
                                 imageVector = Icons.Default.Star,
                                 contentDescription = null,
-                                modifier = Modifier.size(56.dp),
+                                modifier = Modifier.size(56.adp()),
                                 tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
                             )
                             Text(
                                 "No tienes animes guardados",
                                 fontFamily = PoppinsBold,
-                                fontSize = 16.sp
+                                fontSize = 16.asp()
                             )
                             Text(
                                 "Agrega animes a tu lista para poder armar tu Top 5",
                                 fontFamily = PoppinsRegular,
-                                fontSize = 14.sp,
+                                fontSize = 14.asp(),
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                                 textAlign = TextAlign.Center,
                                 modifier = Modifier.padding(horizontal = 32.dp)
@@ -461,7 +463,7 @@ private fun Top5SlotCard(
         Surface(
             modifier = Modifier
                 .padding(4.dp)
-                .size(18.dp)
+                .size(18.adp())
                 .align(Alignment.TopStart),
             shape = RoundedCornerShape(5.dp),
             color = positionColor
@@ -469,7 +471,7 @@ private fun Top5SlotCard(
             Box(contentAlignment = Alignment.Center) {
                 Text(
                     text = "$position",
-                    fontSize = 9.sp,
+                    fontSize = 9.asp(),
                     fontFamily = PoppinsBold,
                     color = if (position <= 2) Color.Black else Color.White
                 )
@@ -483,7 +485,7 @@ private fun Top5SlotCard(
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
                 modifier = Modifier
-                    .size(22.dp)
+                    .size(22.adp())
                     .align(Alignment.Center)
             )
         }
@@ -494,7 +496,7 @@ private fun Top5SlotCard(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(3.dp)
-                    .size(16.dp)
+                    .size(16.adp())
                     .clip(CircleShape)
                     .background(Color.Black.copy(alpha = 0.65f))
                     .clickable(onClick = onRemove),
@@ -561,7 +563,7 @@ private fun AnimePickerCard(
                 contentDescription = anime.title,
                 modifier = Modifier
                     .width(50.dp)
-                    .height(70.dp)
+                    .height(70.adp())
                     .clip(RoundedCornerShape(8.dp)),
                 contentScale = ContentScale.Crop
             )
@@ -573,7 +575,7 @@ private fun AnimePickerCard(
             ) {
                 Text(
                     text = anime.title,
-                    fontSize = 15.sp,
+                    fontSize = 15.asp(),
                     fontFamily = PoppinsBold,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
@@ -594,14 +596,14 @@ private fun AnimePickerCard(
                     )
                     Text(
                         text = anime.userScore.toString(),
-                        fontSize = 12.sp,
+                        fontSize = 12.asp(),
                         fontFamily = PoppinsRegular,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
                     )
                     if (!anime.statusUser.isNullOrBlank()) {
                         Text(
                             text = "· ${anime.statusUser}",
-                            fontSize = 12.sp,
+                            fontSize = 12.asp(),
                             fontFamily = PoppinsRegular,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
                         )
@@ -615,12 +617,12 @@ private fun AnimePickerCard(
                     Surface(
                         shape = RoundedCornerShape(8.dp),
                         color = positionColor,
-                        modifier = Modifier.size(32.dp)
+                        modifier = Modifier.size(32.adp())
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             Text(
                                 text = "#$slotPosition",
-                                fontSize = 11.sp,
+                                fontSize = 11.asp(),
                                 fontFamily = PoppinsBold,
                                 color = if (slotPosition!! <= 2) Color.Black else Color.White
                             )
@@ -644,7 +646,7 @@ private fun AnimePickerCard(
                                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                             modifier = Modifier
                                 .padding(5.dp)
-                                .size(18.dp)
+                                .size(18.adp())
                         )
                     }
                 }
@@ -664,7 +666,7 @@ private fun AnimePickerCard(
                             tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f),
                             modifier = Modifier
                                 .padding(5.dp)
-                                .size(18.dp)
+                                .size(18.adp())
                         )
                     }
                 }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/report/ReportErrorScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/report/ReportErrorScreen.kt
@@ -44,6 +44,8 @@ import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun ReportErrorScreen(
@@ -95,7 +97,7 @@ fun ReportErrorScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp)
+                .height(56.adp())
                 .background(MaterialTheme.colorScheme.background)
         ) {
             IconButton(
@@ -111,7 +113,7 @@ fun ReportErrorScreen(
             Text(
                 text = "Reportar Error",
                 color = MaterialTheme.colorScheme.onSurface,
-                fontSize = 20.sp,
+                fontSize = 20.asp(),
                 fontFamily = PoppinsBold,
                 modifier = Modifier.align(Alignment.Center)
             )
@@ -129,9 +131,9 @@ fun ReportErrorScreen(
             Text(
                 text = "Completa los campos para reportar un error. Al enviar se abrirá tu aplicación de email.\n\nReportar los errores que encuentres nos ayuda a corregirlos y mejorar nuestra aplicación y la experiencia de usuario, gracias por tu colaboracion!",
                 fontFamily = PoppinsRegular,
-                fontSize = 14.sp,
+                fontSize = 14.asp(),
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                lineHeight = 20.sp
+                lineHeight = 20.asp()
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -140,7 +142,7 @@ fun ReportErrorScreen(
             Text(
                 text = "Tu Email",
                 fontFamily = PoppinsBold,
-                fontSize = 16.sp,
+                fontSize = 16.asp(),
                 color = MaterialTheme.colorScheme.onSurface
             )
 
@@ -173,7 +175,7 @@ fun ReportErrorScreen(
             Text(
                 text = "Descripción del Error",
                 fontFamily = PoppinsBold,
-                fontSize = 16.sp,
+                fontSize = 16.asp(),
                 color = MaterialTheme.colorScheme.onSurface
             )
 
@@ -182,7 +184,7 @@ fun ReportErrorScreen(
                 onValueChange = { reportText = it },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(300.dp),
+                    .height(300.adp()),
                 placeholder = {
                     Text(
                         placeholder,
@@ -246,7 +248,7 @@ fun ReportErrorScreen(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(56.dp),
+                    .height(56.adp()),
                 shape = RoundedCornerShape(12.dp),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.primary
@@ -261,7 +263,7 @@ fun ReportErrorScreen(
                 Text(
                     text = "Enviar Reporte",
                     fontFamily = PoppinsBold,
-                    fontSize = 16.sp
+                    fontSize = 16.asp()
                 )
             }
 

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
@@ -97,6 +97,8 @@ import com.yumedev.seijakulist.ui.components.NoInternetScreen
 import com.yumedev.seijakulist.ui.navigation.AppDestinations
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -251,14 +253,14 @@ private fun SearchHeader(
                     imageVector = Icons.Default.Search,
                     contentDescription = "Buscar",
                     tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(22.dp)
+                    modifier = Modifier.size(22.adp())
                 )
             },
             trailingIcon = {
                 when {
                     isLoading -> {
                         CircularProgressIndicator(
-                            modifier = Modifier.size(20.dp),
+                            modifier = Modifier.size(20.adp()),
                             color = MaterialTheme.colorScheme.primary,
                             strokeWidth = 2.dp
                         )
@@ -266,13 +268,13 @@ private fun SearchHeader(
                     searchQuery.isNotBlank() -> {
                         IconButton(
                             onClick = onClearSearch,
-                            modifier = Modifier.size(36.dp)
+                            modifier = Modifier.size(36.adp())
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Clear,
                                 contentDescription = "Limpiar búsqueda",
                                 tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                                modifier = Modifier.size(20.dp)
+                                modifier = Modifier.size(20.adp())
                             )
                         }
                     }
@@ -320,14 +322,14 @@ private fun SearchFilters(
                     Text(
                         text = filter,
                         fontFamily = if (isSelected) PoppinsBold else PoppinsRegular,
-                        fontSize = 14.sp
+                        fontSize = 14.asp()
                     )
                 },
                 leadingIcon = {
                     Icon(
                         imageVector = icon,
                         contentDescription = null,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(18.adp())
                     )
                 },
                 trailingIcon = if (filter == "Generos") {
@@ -335,7 +337,7 @@ private fun SearchFilters(
                         Icon(
                             imageVector = Icons.Default.ArrowDropDown,
                             contentDescription = "Ver géneros",
-                            modifier = Modifier.size(20.dp)
+                            modifier = Modifier.size(20.adp())
                         )
                     }
                 } else null,
@@ -408,7 +410,7 @@ private fun SearchContent(
                     Text(
                         text = "${animeList.size}+ resultados encontrados",
                         fontFamily = PoppinsRegular,
-                        fontSize = 14.sp,
+                        fontSize = 14.asp(),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                         modifier = Modifier.padding(bottom = 4.dp)
                     )
@@ -437,7 +439,7 @@ private fun SearchContent(
                             contentAlignment = Alignment.Center
                         ) {
                             CircularProgressIndicator(
-                                modifier = Modifier.size(32.dp),
+                                modifier = Modifier.size(32.adp()),
                                 color = MaterialTheme.colorScheme.primary,
                                 strokeWidth = 3.dp
                             )
@@ -445,7 +447,7 @@ private fun SearchContent(
                     }
                 }
                 item {
-                    Spacer(Modifier.height(100.dp))
+                    Spacer(Modifier.height(100.adp()))
                 }
             }
         }
@@ -467,7 +469,7 @@ private fun EmptySearchState(searchQuery: String) {
         Icon(
             imageVector = Icons.Default.Search,
             contentDescription = null,
-            modifier = Modifier.size(80.dp),
+            modifier = Modifier.size(80.adp()),
             tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
         )
         Spacer(modifier = Modifier.height(16.dp))
@@ -478,7 +480,7 @@ private fun EmptySearchState(searchQuery: String) {
                 "No se encontraron resultados"
             },
             fontFamily = PoppinsBold,
-            fontSize = 20.sp,
+            fontSize = 20.asp(),
             color = MaterialTheme.colorScheme.onSurface
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -490,9 +492,9 @@ private fun EmptySearchState(searchQuery: String) {
             },
             fontFamily = PoppinsRegular,
             textAlign = TextAlign.Center,
-            fontSize = 14.sp,
+            fontSize = 14.asp(),
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-            lineHeight = 20.sp
+            lineHeight = 20.asp()
         )
     }
 }
@@ -552,12 +554,12 @@ fun AnimeCardItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(170.dp)
+                .height(170.adp())
         ) {
             // Imagen con efectos profesionales
             Box(
                 modifier = Modifier
-                    .width(120.dp)
+                    .width(120.adp())
                     .fillMaxHeight()
             ) {
                 // Imagen principal con placeholder
@@ -611,7 +613,7 @@ fun AnimeCardItem(
                         Text(
                             text = String.format("%.1f", anime.score),
                             color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 13.sp,
+                            fontSize = 13.asp(),
                             fontFamily = PoppinsBold,
                             letterSpacing = 0.2.sp
                         )
@@ -636,9 +638,9 @@ fun AnimeCardItem(
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                         color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 15.sp,
+                        fontSize = 15.asp(),
                         fontFamily = PoppinsBold,
-                        lineHeight = 19.sp,
+                        lineHeight = 19.asp(),
                         letterSpacing = 0.sp
                     )
 
@@ -692,7 +694,7 @@ fun AnimeCardItem(
                         },
                         shape = CircleShape,
                         color = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
-                        modifier = Modifier.size(38.dp)
+                        modifier = Modifier.size(38.adp())
                     ) {
                         Box(
                             contentAlignment = Alignment.Center,
@@ -702,7 +704,7 @@ fun AnimeCardItem(
                                 imageVector = Icons.Default.BookmarkBorder,
                                 contentDescription = "Añadir a lista",
                                 tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(20.dp)
+                                modifier = Modifier.size(20.adp())
                             )
                         }
                     }
@@ -749,7 +751,7 @@ private fun StatusBadgePro(status: String) {
             Text(
                 text = emoji,
                 color = statusColor,
-                fontSize = 10.sp,
+                fontSize = 10.asp(),
                 fontFamily = PoppinsBold
             )
 
@@ -758,7 +760,7 @@ private fun StatusBadgePro(status: String) {
                 style = MaterialTheme.typography.labelSmall,
                 color = statusColor,
                 fontFamily = PoppinsBold,
-                fontSize = 11.sp,
+                fontSize = 11.asp(),
                 letterSpacing = 0.2.sp
             )
         }
@@ -787,7 +789,7 @@ private fun GenreChipCompact(genreName: String) {
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSecondaryContainer,
             fontFamily = PoppinsRegular,
-            fontSize = 10.sp,
+            fontSize = 10.asp(),
             letterSpacing = 0.1.sp,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
@@ -815,7 +817,7 @@ private fun InfoRow(
             text = text,
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
-            fontSize = 13.sp,
+            fontSize = 13.asp(),
             fontFamily = PoppinsRegular,
             fontWeight = FontWeight.Medium,
             letterSpacing = 0.1.sp
@@ -842,7 +844,7 @@ private fun InfoChip(
             text = text,
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-            fontSize = 11.sp,
+            fontSize = 11.asp(),
             fontFamily = PoppinsRegular,
             letterSpacing = 0.sp
         )
@@ -891,14 +893,14 @@ fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(190.dp)
+                .height(190.adp())
         ) {
             // Imagen limpia
             AsyncImage(
                 model = anime.images,
                 contentDescription = "Portada de ${anime.title}",
                 modifier = Modifier
-                    .width(130.dp)
+                    .width(130.adp())
                     .fillMaxHeight()
                     .clip(RoundedCornerShape(topStart = 18.dp, bottomStart = 18.dp)),
                 contentScale = ContentScale.Crop
@@ -925,9 +927,9 @@ fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard) {
                             maxLines = 2,
                             overflow = TextOverflow.Ellipsis,
                             color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 17.sp,
+                            fontSize = 17.asp(),
                             fontFamily = PoppinsBold,
-                            lineHeight = 20.sp
+                            lineHeight = 20.asp()
                         )
 
                         // Score compacto
@@ -944,7 +946,7 @@ fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard) {
                             Text(
                                 text = String.format("%.1f", anime.score),
                                 color = MaterialTheme.colorScheme.onSurface,
-                                fontSize = 13.sp,
+                                fontSize = 13.asp(),
                                 fontFamily = PoppinsBold
                             )
                         }
@@ -960,7 +962,7 @@ fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard) {
                             overflow = TextOverflow.Ellipsis,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                            fontSize = 11.sp
+                            fontSize = 11.asp()
                         )
                     }
                 }
@@ -975,14 +977,14 @@ fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard) {
                         text = "${anime.year} • ${anime.episodes} eps",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-                        fontSize = 11.sp
+                        fontSize = 11.asp()
                     )
 
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(18.adp())
                     )
                 }
             }
@@ -1004,7 +1006,7 @@ private fun StatusBadgeMinimal(status: String) {
         style = MaterialTheme.typography.labelSmall,
         color = statusColor,
         fontFamily = PoppinsBold,
-        fontSize = 12.sp
+        fontSize = 12.asp()
     )
 }
 
@@ -1039,7 +1041,7 @@ private fun GenresBottomSheet(
                 Text(
                     text = "Seleccionar género",
                     fontFamily = PoppinsBold,
-                    fontSize = 20.sp,
+                    fontSize = 20.asp(),
                     color = MaterialTheme.colorScheme.onSurface
                 )
                 IconButton(onClick = onDismiss) {
@@ -1060,7 +1062,7 @@ private fun GenresBottomSheet(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(300.dp),
+                            .height(300.adp()),
                         contentAlignment = Alignment.Center
                     ) {
                         LoadingScreen()
@@ -1146,7 +1148,7 @@ private fun GenreChip(
             Text(
                 text = genre.name,
                 fontFamily = if (isSelected) PoppinsBold else PoppinsRegular,
-                fontSize = 14.sp,
+                fontSize = 14.asp(),
                 color = if (isSelected) {
                     MaterialTheme.colorScheme.onPrimaryContainer
                 } else {
@@ -1162,14 +1164,14 @@ private fun GenreChip(
                     imageVector = Icons.Default.CheckCircle,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(20.adp())
                 )
             } else {
                 Text(
                     text = genre.count.toString(),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-                    fontSize = 12.sp
+                    fontSize = 12.asp()
                 )
             }
         }
@@ -1223,13 +1225,13 @@ private fun AddAnimeDialog(
                         imageVector = Icons.Default.Favorite,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(28.dp)
+                        modifier = Modifier.size(28.adp())
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                     Text(
                         text = "Añadir a mi lista",
                         color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 26.sp,
+                        fontSize = 26.asp(),
                         fontFamily = PoppinsBold
                     )
                 }
@@ -1264,13 +1266,13 @@ private fun AddAnimeDialog(
                                 imageVector = Icons.Default.CheckCircle,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(24.dp)
+                                modifier = Modifier.size(24.adp())
                             )
                             Spacer(modifier = Modifier.width(12.dp))
                             Text(
                                 text = "Estado",
                                 color = MaterialTheme.colorScheme.onSurface,
-                                fontSize = 20.sp,
+                                fontSize = 20.asp(),
                                 fontFamily = PoppinsBold
                             )
                             Spacer(modifier = Modifier.weight(1f))
@@ -1287,7 +1289,7 @@ private fun AddAnimeDialog(
                                         text = "✓",
                                         color = Color.Black,
                                         fontWeight = FontWeight.Bold,
-                                        fontSize = 14.sp
+                                        fontSize = 14.asp()
                                     )
                                 }
                             }
@@ -1297,7 +1299,7 @@ private fun AddAnimeDialog(
                             onClick = { expandedStatus = !expandedStatus },
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .height(56.dp),
+                                .height(56.adp()),
                             colors = ButtonDefaults.buttonColors(
                                 containerColor = if (selectedStatus != null) statusColors[selectedStatus]!! else MaterialTheme.colorScheme.surface,
                                 contentColor = if (selectedStatus != null) Color.Black else MaterialTheme.colorScheme.onSurface
@@ -1316,7 +1318,7 @@ private fun AddAnimeDialog(
                                     text = selectedStatus ?: "Seleccionar estado",
                                     modifier = Modifier.weight(1f),
                                     textAlign = if (selectedStatus != null) TextAlign.Center else TextAlign.Start,
-                                    fontSize = 16.sp,
+                                    fontSize = 16.asp(),
                                     fontWeight = FontWeight.SemiBold
                                 )
                                 val rotation: Float by animateFloatAsState(
@@ -1331,7 +1333,7 @@ private fun AddAnimeDialog(
                                     imageVector = Icons.Default.ArrowDropDown,
                                     contentDescription = null,
                                     modifier = Modifier
-                                        .size(28.dp)
+                                        .size(28.adp())
                                         .graphicsLayer { rotationZ = rotation }
                                 )
                             }
@@ -1346,7 +1348,7 @@ private fun AddAnimeDialog(
                                 columns = GridCells.Fixed(2),
                                 modifier = Modifier
                                     .padding(top = 12.dp)
-                                    .height(200.dp),
+                                    .height(200.adp()),
                                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                                 verticalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
@@ -1396,7 +1398,7 @@ private fun AddAnimeDialog(
                                                 text = status,
                                                 color = Color.Black,
                                                 fontWeight = FontWeight.Bold,
-                                                fontSize = 15.sp,
+                                                fontSize = 15.asp(),
                                                 textAlign = TextAlign.Center
                                             )
                                         }
@@ -1440,13 +1442,13 @@ private fun AddAnimeDialog(
                                     imageVector = Icons.Default.Star,
                                     contentDescription = null,
                                     tint = Color(0xFFFFD700),
-                                    modifier = Modifier.size(24.dp)
+                                    modifier = Modifier.size(24.adp())
                                 )
                                 Spacer(modifier = Modifier.width(12.dp))
                                 Text(
                                     text = "Calificación",
                                     color = MaterialTheme.colorScheme.onSurface,
-                                    fontSize = 20.sp,
+                                    fontSize = 20.asp(),
                                     fontFamily = PoppinsBold
                                 )
                             }
@@ -1471,7 +1473,7 @@ private fun AddAnimeDialog(
                                         "No puedes puntuar un anime planeado",
                                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                                         textAlign = TextAlign.Center,
-                                        fontSize = 14.sp
+                                        fontSize = 14.asp()
                                     )
                                 }
                             }
@@ -1507,13 +1509,13 @@ private fun AddAnimeDialog(
                                 imageVector = Icons.Default.Edit,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(24.dp)
+                                modifier = Modifier.size(24.adp())
                             )
                             Spacer(modifier = Modifier.width(12.dp))
                             Text(
                                 text = "Opinión",
                                 color = MaterialTheme.colorScheme.onSurface,
-                                fontSize = 20.sp,
+                                fontSize = 20.asp(),
                                 fontFamily = PoppinsBold
                             )
                         }
@@ -1526,7 +1528,7 @@ private fun AddAnimeDialog(
                             },
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .height(180.dp),
+                                .height(180.adp()),
                             colors = OutlinedTextFieldDefaults.colors(
                                 focusedContainerColor = MaterialTheme.colorScheme.surface,
                                 unfocusedContainerColor = MaterialTheme.colorScheme.surface,
@@ -1561,7 +1563,7 @@ private fun AddAnimeDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .height(56.dp),
+                        .height(56.adp()),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.primary,
                         contentColor = Color.White,
@@ -1582,12 +1584,12 @@ private fun AddAnimeDialog(
                         Icon(
                             imageVector = Icons.Default.Check,
                             contentDescription = null,
-                            modifier = Modifier.size(22.dp)
+                            modifier = Modifier.size(22.adp())
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
                             text = "Guardar en mi lista",
-                            fontSize = 16.sp,
+                            fontSize = 16.asp(),
                             fontWeight = FontWeight.Bold
                         )
                     }
@@ -1644,7 +1646,7 @@ private fun RatingBar(
                             scaleX = size
                             scaleY = size
                         }
-                        .size(32.dp)
+                        .size(32.adp())
                         .clickable {
                             val newRating = if (rating == starValue) {
                                 starValue - 0.5f
@@ -1667,7 +1669,7 @@ private fun RatingBar(
                 "Tu calificación: %.1f / %d".format(rating, stars)
             },
             color = MaterialTheme.colorScheme.onSurface,
-            fontSize = 16.sp,
+            fontSize = 16.asp(),
             fontWeight = FontWeight.Bold,
             fontFamily = PoppinsBold,
             modifier = Modifier

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/splash/SplashScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/splash/SplashScreen.kt
@@ -43,6 +43,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @Composable
 fun SplashScreen(
@@ -117,7 +119,7 @@ fun SplashScreen(
                 painter = painterResource(id = R.drawable.logo),
                 contentDescription = "SeijakuList Logo",
                 modifier = Modifier
-                    .size(140.dp)
+                    .size(140.adp())
                     .scale(logoScale)
                     .graphicsLayer { alpha = logoAlpha }
                     .clip(RoundedCornerShape(28.dp))
@@ -129,7 +131,7 @@ fun SplashScreen(
             Text(
                 text = "Seijaku List",
                 fontFamily = PoppinsBold,
-                fontSize = 32.sp,
+                fontSize = 32.asp(),
                 fontWeight = FontWeight.Bold,
                 color = Color.White,
                 modifier = Modifier.graphicsLayer { alpha = textAlpha }
@@ -140,7 +142,7 @@ fun SplashScreen(
             // Tagline
             Text(
                 text = "Tu colección de anime y mangas",
-                fontSize = 14.sp,
+                fontSize = 14.asp(),
                 color = Color.White.copy(alpha = 0.8f),
                 modifier = Modifier.graphicsLayer { alpha = textAlpha }
             )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/viewmore/ViewMoreScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/viewmore/ViewMoreScreen.kt
@@ -44,6 +44,8 @@ import com.yumedev.seijakulist.ui.components.LoadingScreen
 import com.yumedev.seijakulist.ui.components.NoInternetScreen
 import com.yumedev.seijakulist.ui.theme.PoppinsBold
 import com.yumedev.seijakulist.ui.theme.PoppinsMedium
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -110,7 +112,7 @@ fun ViewMoreScreen(
                             Text(
                                 text = filterLabels[index],
                                 fontFamily = PoppinsMedium,
-                                fontSize = 12.sp
+                                fontSize = 12.asp()
                             )
                         },
                         colors = FilterChipDefaults.filterChipColors(
@@ -161,7 +163,7 @@ fun ViewMoreScreen(
                         ) {
                             Text(
                                 text = "No se encontraron animes",
-                                fontSize = 18.sp,
+                                fontSize = 18.asp(),
                                 fontFamily = PoppinsBold,
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                                 textAlign = TextAlign.Center
@@ -169,7 +171,7 @@ fun ViewMoreScreen(
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
                                 text = "Intenta con otra sección",
-                                fontSize = 14.sp,
+                                fontSize = 14.asp(),
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
                                 textAlign = TextAlign.Center
                             )
@@ -213,7 +215,7 @@ fun ViewMoreScreen(
                                     contentAlignment = Alignment.Center
                                 ) {
                                     CircularProgressIndicator(
-                                        modifier = Modifier.size(32.dp),
+                                        modifier = Modifier.size(32.adp()),
                                         color = MaterialTheme.colorScheme.primary,
                                         strokeWidth = 3.dp
                                     )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/theme/ResponsiveUtils.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/theme/ResponsiveUtils.kt
@@ -1,0 +1,33 @@
+package com.yumedev.seijakulist.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private const val REFERENCE_WIDTH_DP = 420f
+private const val SCALE_MIN = 0.75f
+private const val SCALE_MAX = 1.0f
+
+@Composable
+private fun screenScale(): Float {
+    val screenWidthDp = LocalConfiguration.current.screenWidthDp.toFloat()
+    return (screenWidthDp / REFERENCE_WIDTH_DP).coerceIn(SCALE_MIN, SCALE_MAX)
+}
+
+@Composable
+fun Int.adp(): Dp = (this * screenScale()).dp
+
+@Composable
+fun Float.adp(): Dp = (this * screenScale()).dp
+
+@Composable
+fun Double.adp(): Dp = (this * screenScale()).dp
+
+@Composable
+fun Int.asp(): TextUnit = (this * screenScale()).sp
+
+@Composable
+fun Float.asp(): TextUnit = (this * screenScale()).sp


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  - Introduce `ResponsiveUtils.kt` with `adp()` and `asp()` extension functions that scale layout dimensions and typography based on the device screen width                                                                                                                                                        
  - Replace ~876 hardcoded `dp`/`sp` values across 50 UI files with adaptive versions
  - Fix the device fragmentation issue where layouts appeared disproportionately large on smaller or lower-density screens                                                                                                                                                                                          
                  
  ## Problem                                                                                                                                                                                                                                                                                                        
                  
  All dimension values were hardcoded for a single reference device (~430dp width). On smaller phones (320–360dp), cards, images, and text occupied proportionally more space, breaking the visual design.                                                                                                          
   
  ## Implementation                                                                                                                                                                                                                                                                                                 
                  
  **`ResponsiveUtils.kt`** — screen-width-aware scaling system:                                                                                                                                                                                                                                                     
  - **Reference width:** 420dp (Moto G82 / modern mid-range phones)
  - **Scale range:** 0.75x min → 1.0x max (never enlarges beyond original values)
                                                                                                                                                                                                                                                                                                                    
  | Device width | Applied scale |
  |---|---|                                                                                                                                                                                                                                                                                                         
  | ~320dp (small phones) | 0.75x → 25% smaller |
  | ~360dp (mid phones) | 0.86x → ~15% smaller |
  | ~393dp (Pixel / Galaxy S) | 0.94x → ~6% smaller |                                                                                                                                                                                                                                                               
  | 420dp+ (Moto G82 and above) | 1.0x → original size |
                                                                                                                                                                                                                                                                                                                    
  **What gets scaled:**
  - `.height(X.dp)` → `.height(X.adp())` for values >= 40dp                                                                                                                                                                                                                                                         
  - `.width(X.dp)` → `.width(X.adp())` for values >= 60dp
  - `.size(X.dp)` → `.size(X.adp())` for icons >= 16dp                                                                                                                                                                                                                                                              
  - `fontSize = X.sp` and `lineHeight = X.sp` → `.asp()` across all files
                                                                                                                                                                                                                                                                                                                    
  **What stays unchanged:** corner radii, elevations, borders, small paddings (<= 36dp) — these are design tokens that should not scale.                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
  ## Modified files                                                                                                                                                                                                                                                                                                 
                  
  - `ui/theme/ResponsiveUtils.kt` — new file with the scaling system
  - 50 files across `ui/components/` and `ui/screens/` — dp/sp replacements
  - `ui/theme/Type.kt` — unchanged (Typography object is not `@Composable`)                                                                                                                                                                                                                                         