### PR TITLE
Redesign AnimeCardItem component and improve data parsing in Search Screen

### DIFF
--- a/app/src/main/java/com/yumedev/seijakulist/data/remote/models/anime_random/AnimeRandomDto.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/data/remote/models/anime_random/AnimeRandomDto.kt
@@ -1,5 +1,6 @@
 package com.yumedev.seijakulist.data.remote.models.anime_random
 
+import com.yumedev.seijakulist.data.remote.models.AiredDto
 import com.yumedev.seijakulist.data.remote.models.GenreDto
 import com.yumedev.seijakulist.data.remote.models.ImagesDto
 import com.google.gson.annotations.SerializedName
@@ -10,7 +11,9 @@ data class AnimeCardDto(
     val images: ImagesDto?,
     val score: Float?,
     val status: String?,
+    val type: String?,
     val genres: List<GenreDto?>,
     val year: Int?,
+    val aired: AiredDto?,
     val episodes: Int?,
 )

--- a/app/src/main/java/com/yumedev/seijakulist/data/repository/AnimeRepository.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/data/repository/AnimeRepository.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.first
 import com.yumedev.seijakulist.data.mapper.toCharacterPictures
 import com.yumedev.seijakulist.data.mapper.toProducerDetail
 import com.yumedev.seijakulist.data.remote.api.JikanApiService
+import com.yumedev.seijakulist.util.getDisplayYear
+import com.yumedev.seijakulist.util.getDisplayEpisodes
 import com.yumedev.seijakulist.data.remote.models.AnimeDetailDto
 import com.yumedev.seijakulist.data.remote.models.AnimeDetailResponseDto
 import com.yumedev.seijakulist.data.remote.models.anime_random.AnimeCardResponseDto
@@ -196,9 +198,10 @@ class AnimeRepository @Inject constructor(
                 images = animeDto?.images?.webp?.largeImageUrl ?: "URL de imagen predeterminada",
                 score = animeDto?.score ?: 0.0f,
                 status = animeDto?.status ?: "Sin estado",
+                type = animeDto?.type ?: "TV",
                 genres = animeDto?.genres ?: emptyList(),
-                year = (animeDto?.year ?: "N/A").toString(),
-                episodes = (animeDto?.episodes ?: "N/A").toString()
+                year = getDisplayYear(animeDto?.year, animeDto?.aired?.airedString),
+                episodes = getDisplayEpisodes(animeDto?.episodes, animeDto?.type, animeDto?.status)
             )
         }
 
@@ -506,9 +509,10 @@ class AnimeRepository @Inject constructor(
                 images = animeDto.images?.webp?.largeImageUrl ?: "URL de imagen predeterminada",
                 score = animeDto.score ?: 0.0f,
                 status = animeDto.status ?: "Sin estado",
+                type = animeDto.type ?: "TV",
                 genres = animeDto.genres ?: emptyList(),
-                year = (animeDto.year ?: "N/A").toString(),
-                episodes = (animeDto.episodes ?: "N/A").toString()
+                year = getDisplayYear(animeDto.year, animeDto.aired?.airedString),
+                episodes = getDisplayEpisodes(animeDto.episodes, animeDto.type, animeDto.status)
             )
         }
     }

--- a/app/src/main/java/com/yumedev/seijakulist/domain/models/AnimeCard.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/domain/models/AnimeCard.kt
@@ -10,6 +10,7 @@ data class AnimeCard(
     val images: String,
     val score: Float,
     val status: String,
+    val type: String,
     val genres: List<GenreDto?>,
     val year: String,
     val episodes: String,

--- a/app/src/main/java/com/yumedev/seijakulist/domain/usecase/GetAnimeRandomUseCase.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/domain/usecase/GetAnimeRandomUseCase.kt
@@ -3,6 +3,8 @@ package com.yumedev.seijakulist.domain.usecase
 import com.yumedev.seijakulist.data.repository.AnimeRepository
 import com.yumedev.seijakulist.domain.models.Anime
 import com.yumedev.seijakulist.domain.models.AnimeCard
+import com.yumedev.seijakulist.util.getDisplayYear
+import com.yumedev.seijakulist.util.getDisplayEpisodes
 import javax.inject.Inject
 
 class GetAnimeRandomUseCase @Inject constructor(
@@ -21,9 +23,10 @@ class GetAnimeRandomUseCase @Inject constructor(
                 ?: "URL de imagen predeterminada",
             score = animeDto?.score ?: 0.0f,
             status = animeDto?.status ?: "Sin estado",
+            type = animeDto?.type ?: "TV",
             genres = animeDto?.genres ?: emptyList(),
-            year = (animeDto?.year ?: "N/A").toString(),
-            episodes = (animeDto?.episodes ?: "N/A").toString()
+            year = getDisplayYear(animeDto?.year, animeDto?.aired?.airedString),
+            episodes = getDisplayEpisodes(animeDto?.episodes, animeDto?.type, animeDto?.status)
         )
 
         return animeDomain

--- a/app/src/main/java/com/yumedev/seijakulist/domain/usecase/GetAnimeSearchUseCase.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/domain/usecase/GetAnimeSearchUseCase.kt
@@ -3,6 +3,8 @@ package com.yumedev.seijakulist.domain.usecase
 import com.yumedev.seijakulist.data.repository.AnimeRepository
 import com.yumedev.seijakulist.domain.models.Anime
 import com.yumedev.seijakulist.domain.models.AnimeCard
+import com.yumedev.seijakulist.util.getDisplayYear
+import com.yumedev.seijakulist.util.getDisplayEpisodes
 import javax.inject.Inject
 
 class GetAnimeSearchUseCase @Inject constructor(
@@ -26,9 +28,10 @@ class GetAnimeSearchUseCase @Inject constructor(
                     ?: "URL de imagen predeterminada",
                 score = animeDto?.score ?: 0.0f,
                 status = animeDto?.status ?: "Sin estado",
+                type = animeDto?.type ?: "TV",
                 genres = animeDto?.genres ?: emptyList(),
-                year = (animeDto?.year ?: "N/A").toString(),
-                episodes = (animeDto?.episodes ?: "N/A").toString()
+                year = getDisplayYear(animeDto?.year, animeDto?.aired?.airedString),
+                episodes = getDisplayEpisodes(animeDto?.episodes, animeDto?.type, animeDto?.status)
             )
         }
 

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yumedev.seijakulist.data.local.entities.AnimeEntity
 import com.yumedev.seijakulist.data.local.entities.SearchHistoryEntity
+import com.yumedev.seijakulist.data.remote.models.SearchAnimeResponse
 import com.yumedev.seijakulist.data.repository.AnimeLocalRepository
 import com.yumedev.seijakulist.data.repository.AnimeRepository
 import com.yumedev.seijakulist.data.repository.FirestoreAnimeRepository
@@ -294,7 +295,7 @@ class AnimeSearchViewModel @Inject constructor(
     }
 
     // Helper method to map SearchAnimeResponse to List<AnimeCard>
-    private fun mapSearchResponseToCards(response: com.yumedev.seijakulist.data.remote.models.SearchAnimeResponse): List<AnimeCard> {
+    private fun mapSearchResponseToCards(response: SearchAnimeResponse): List<AnimeCard> {
         return response.data.mapNotNull { animeDto ->
             if (animeDto == null) return@mapNotNull null
             AnimeCard(
@@ -305,7 +306,8 @@ class AnimeSearchViewModel @Inject constructor(
                 status = animeDto.status ?: "Sin estado",
                 genres = animeDto.genres ?: emptyList(),
                 year = (animeDto.year ?: "N/A").toString(),
-                episodes = (animeDto.episodes ?: "N/A").toString()
+                episodes = (animeDto.episodes ?: "N/A").toString(),
+                type = animeDto.type ?: "TV"
             )
         }
     }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
@@ -825,7 +825,7 @@ private fun SearchContent(
                 state = listState,
                 modifier = Modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                contentPadding = PaddingValues(vertical = 8.dp)
             ) {
             item {
                 ContentTypeFilters(
@@ -852,7 +852,7 @@ private fun SearchContent(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = 8.dp),
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -888,12 +888,14 @@ private fun SearchContent(
                         fontFamily = PoppinsRegular,
                         fontSize = 14.asp(),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                        modifier = Modifier.padding(bottom = 4.dp)
+                        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 4.dp)
                     )
                 }
             }
             items(animeList, key = { it.malId }) { anime ->
-                AnimeCardItem(navController = navController, anime = anime)
+                Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    AnimeCardItem(navController = navController, anime = anime)
+                }
             }
             if (isLoadingMore) {
                 item {
@@ -1217,109 +1219,73 @@ fun AnimeCardItem(
                 .fillMaxWidth()
                 .height(170.adp())
         ) {
-            // ── Cover con badge de score ──────────────────────────────────
-            Box(
+            // ── Cover limpia (sin badges) ──────────────────────────────────
+            AsyncImage(
+                model = anime.images,
+                contentDescription = "Portada de ${anime.title}",
                 modifier = Modifier
                     .width(120.adp())
                     .fillMaxHeight()
-            ) {
-                AsyncImage(
-                    model = anime.images,
-                    contentDescription = "Portada de ${anime.title}",
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clip(RoundedCornerShape(topStart = 18.dp, bottomStart = 18.dp)),
-                    contentScale = ContentScale.Crop
-                )
-                // Gradiente sobre la imagen
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(
-                            Brush.verticalGradient(
-                                listOf(
-                                    Color.Black.copy(alpha = 0.3f),
-                                    Color.Transparent,
-                                    Color.Black.copy(alpha = 0.5f)
-                                )
-                            )
-                        )
-                )
-                // Badge de score
-                Surface(
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(8.dp),
-                    shape = RoundedCornerShape(10.dp),
-                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
-                    shadowElevation = 6.dp,
-                    tonalElevation = 2.dp
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 5.dp),
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Star,
-                            contentDescription = "Calificación",
-                            tint = Color(0xFFFFB300),
-                            modifier = Modifier.size(14.dp)
-                        )
-                        Text(
-                            text = String.format("%.1f", anime.score),
-                            color = MaterialTheme.colorScheme.onSurface,
-                            fontSize = 13.asp(),
-                            fontFamily = PoppinsBold,
-                            letterSpacing = 0.2.sp
-                        )
-                    }
-                }
-            }
+                    .clip(RoundedCornerShape(topStart = 18.dp, bottomStart = 18.dp)),
+                contentScale = ContentScale.Crop
+            )
 
-            // ── Info ──────────────────────────────────────────────────────
+            // ── Info rediseñada ──────────────────────────────────────────────
             Column(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxHeight()
-                    .padding(12.dp),
+                    .padding(start = 14.dp, end = 14.dp, top = 14.dp, bottom = 12.dp),
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(7.dp)) {
+                    // 1. Título (1 línea, prominente)
                     Text(
                         text = anime.title,
-                        maxLines = 2,
+                        maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 15.asp(),
+                        fontSize = 16.asp(),
                         fontFamily = PoppinsBold,
-                        lineHeight = 19.asp(),
+                        lineHeight = 20.asp(),
                         letterSpacing = 0.sp
                     )
-                    StatusBadge(status = anime.status)
+
+                    // 2. Type + Score + Status en formato Pill (misma Row)
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        TypePill(type = anime.type)
+                        ScorePill(score = anime.score)
+                        StatusPill(status = anime.status)
+                    }
+
+                    // 3. Géneros (hasta 3)
                     if (anime.genres.isNotEmpty()) {
                         LazyRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                            items(anime.genres.take(2)) { genre ->
+                            items(anime.genres.take(3)) { genre ->
                                 genre?.name?.let { GenreChipCompact(genreName = it) }
                             }
-                            if (anime.genres.size > 2) {
-                                item { GenreChipCompact(genreName = "+${anime.genres.size - 2}") }
+                            if (anime.genres.size > 3) {
+                                item { GenreChipCompact(genreName = "+${anime.genres.size - 3}") }
                             }
                         }
                     }
                 }
 
+                // 4. Bottom: Metadata Pills + Botón
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        InfoChip(icon = Icons.Default.CalendarToday, text = anime.year)
-                        InfoChip(icon = Icons.Default.PlayCircleOutline, text = "${anime.episodes}")
+                        YearPill(year = anime.year)
+                        EpisodesPill(episodes = anime.episodes)
                     }
                     Surface(
                         onClick = {
@@ -1327,7 +1293,7 @@ fun AnimeCardItem(
                         },
                         shape = CircleShape,
                         color = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
-                        modifier = Modifier.size(38.adp())
+                        modifier = Modifier.size(48.adp())
                     ) {
                         Box(
                             contentAlignment = Alignment.Center,
@@ -1337,7 +1303,7 @@ fun AnimeCardItem(
                                 imageVector = Icons.Default.BookmarkBorder,
                                 contentDescription = "Añadir a lista",
                                 tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(20.adp())
+                                modifier = Modifier.size(22.adp())
                             )
                         }
                     }
@@ -1469,6 +1435,207 @@ fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard) {
 // SUBCOMPONENTES VISUALES
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ═══════════════════════════════════════════════════════════════════════════
+// PILLS COMPACTOS (Type, Score, Status) - Formato unificado
+// ═══════════════════════════════════════════════════════════════════════════
+
+@Composable
+private fun TypePill(type: String) {
+    val (color, displayText) = when (type) {
+        "TV" -> Color(0xFF6366F1) to "TV"
+        "Movie" -> Color(0xFFEC4899) to "Movie"
+        "OVA" -> Color(0xFF8B5CF6) to "OVA"
+        "ONA" -> Color(0xFF14B8A6) to "ONA"
+        "Special" -> Color(0xFFF59E0B) to "Special"
+        "Music" -> Color(0xFF06B6D4) to "Music"
+        else -> MaterialTheme.colorScheme.tertiary to type
+    }
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = color.copy(alpha = 0.18f)
+    ) {
+        Text(
+            text = displayText,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            color = color,
+            fontFamily = PoppinsBold,
+            fontSize = 10.asp(),
+            letterSpacing = 0.4.sp
+        )
+    }
+}
+
+@Composable
+private fun ScorePill(score: Float) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = Color(0xFFFFB300).copy(alpha = 0.18f)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Star,
+                contentDescription = "Calificación",
+                tint = Color(0xFFFFB300),
+                modifier = Modifier.size(11.dp)
+            )
+            Text(
+                text = String.format("%.1f", score),
+                color = Color(0xFFFFB300),
+                fontSize = 10.asp(),
+                fontFamily = PoppinsBold,
+                letterSpacing = 0.3.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusPill(status: String) {
+    val (color, text, dot) = when (status) {
+        "Currently Airing" -> Triple(Color(0xFF10B981), "Emisión", "●")
+        "Finished Airing" -> Triple(MaterialTheme.colorScheme.primary, "Finalizado", "✓")
+        "Not yet aired" -> Triple(Color(0xFFFF9800), "Próximo", "◐")
+        else -> Triple(MaterialTheme.colorScheme.outline, status, "○")
+    }
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = color.copy(alpha = 0.18f)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            horizontalArrangement = Arrangement.spacedBy(3.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = dot, color = color, fontSize = 9.asp(), fontFamily = PoppinsBold)
+            Text(
+                text = text,
+                color = color,
+                fontFamily = PoppinsBold,
+                fontSize = 10.asp(),
+                letterSpacing = 0.3.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun YearPill(year: String) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.6f)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.CalendarToday,
+                contentDescription = "Año",
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                modifier = Modifier.size(10.dp)
+            )
+            Text(
+                text = year,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                fontSize = 10.asp(),
+                fontFamily = PoppinsBold,
+                letterSpacing = 0.3.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpisodesPill(episodes: String) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.6f)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.PlayCircleOutline,
+                contentDescription = "Episodios",
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                modifier = Modifier.size(10.dp)
+            )
+            Text(
+                text = episodes,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                fontSize = 10.asp(),
+                fontFamily = PoppinsBold,
+                letterSpacing = 0.3.sp
+            )
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BADGES (usado en AnimeCardItemMinimal - mantener compatibilidad)
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun TypeBadge(type: String) {
+    val (color, displayText) = when (type) {
+        "TV" -> Color(0xFF6366F1) to "TV"
+        "Movie" -> Color(0xFFEC4899) to "Movie"
+        "OVA" -> Color(0xFF8B5CF6) to "OVA"
+        "ONA" -> Color(0xFF14B8A6) to "ONA"
+        "Special" -> Color(0xFFF59E0B) to "Special"
+        "Music" -> Color(0xFF06B6D4) to "Music"
+        else -> MaterialTheme.colorScheme.tertiary to type
+    }
+    Surface(
+        shape = RoundedCornerShape(6.dp),
+        color = color.copy(alpha = 0.15f)
+    ) {
+        Text(
+            text = displayText,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            color = color,
+            fontFamily = PoppinsBold,
+            fontSize = 10.asp(),
+            letterSpacing = 0.3.sp
+        )
+    }
+}
+
+@Composable
+private fun ScoreChip(score: Float) {
+    Surface(
+        shape = RoundedCornerShape(6.dp),
+        color = Color(0xFFFFB300).copy(alpha = 0.15f)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Star,
+                contentDescription = "Calificación",
+                tint = Color(0xFFFFB300),
+                modifier = Modifier.size(12.dp)
+            )
+            Text(
+                text = String.format("%.1f", score),
+                color = Color(0xFFFFB300),
+                fontSize = 11.asp(),
+                fontFamily = PoppinsBold,
+                letterSpacing = 0.2.sp
+            )
+        }
+    }
+}
+
 @Composable
 private fun StatusBadge(status: String) {
     val (color, text, dot) = when (status) {
@@ -1477,7 +1644,7 @@ private fun StatusBadge(status: String) {
         "Not yet aired" -> Triple(Color(0xFFFF9800), "Próximamente", "◐")
         else -> Triple(MaterialTheme.colorScheme.outline, status, "○")
     }
-    Surface(shape = RoundedCornerShape(8.dp), color = color.copy(alpha = 0.15f)) {
+    Surface(shape = RoundedCornerShape(7.dp), color = color.copy(alpha = 0.15f)) {
         Row(
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -1700,7 +1867,7 @@ private fun ActiveFiltersChips(
 ) {
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = PaddingValues(vertical = 8.dp)
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
     ) {
         // Quick filter chip
         if (selectedQuick != null) {

--- a/app/src/main/java/com/yumedev/seijakulist/util/AnimeDataParser.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/util/AnimeDataParser.kt
@@ -1,0 +1,64 @@
+package com.yumedev.seijakulist.util
+
+/**
+ * Extrae el año desde un string de fecha aired.
+ *
+ * Formatos soportados:
+ * - "jan 19, 2010"
+ * - "apr 3, 2009 to jun 26, 2009"
+ * - "2010"
+ *
+ * @param airedString String con la fecha de emisión
+ * @return El año extraído o null si no se puede parsear
+ */
+fun extractYearFromAired(airedString: String?): Int? {
+    if (airedString.isNullOrBlank()) return null
+
+    // Regex para extraer un año de 4 dígitos
+    val yearRegex = Regex("""\b(\d{4})\b""")
+    val matchResult = yearRegex.find(airedString)
+
+    return matchResult?.groupValues?.get(1)?.toIntOrNull()
+}
+
+/**
+ * Obtiene el año para mostrar en la UI, priorizando el campo year,
+ * y si es null, extrae desde el campo aired.
+ *
+ * @param year Año directo del campo year
+ * @param airedString String de fecha aired
+ * @return String del año o "N/A" si no se puede obtener
+ */
+fun getDisplayYear(year: Int?, airedString: String?): String {
+    return when {
+        year != null && year > 0 -> year.toString()
+        else -> extractYearFromAired(airedString)?.toString() ?: "N/A"
+    }
+}
+
+/**
+ * Obtiene el display de episodios, manejando casos especiales según el tipo.
+ *
+ * @param episodes Número de episodios
+ * @param type Tipo de anime (TV, Movie, OVA, etc.)
+ * @param status Estado del anime (Currently Airing, Finished Airing, etc.)
+ * @return String formateado para mostrar episodios
+ */
+fun getDisplayEpisodes(episodes: Int?, type: String?, status: String?): String {
+    return when {
+        // Movies siempre tienen 1 episodio
+        type?.equals("Movie", ignoreCase = true) == true -> "1"
+
+        // Si tiene episodios definidos, mostrarlos
+        episodes != null && episodes > 0 -> episodes.toString()
+
+        // Si está en emisión y no tiene episodios, mostrar "?"
+        status?.contains("Airing", ignoreCase = true) == true -> "?"
+
+        // Si es Special, OVA, ONA sin episodios definidos
+        type in listOf("Special", "OVA", "ONA") -> "?"
+
+        // Default
+        else -> "?"
+    }
+}


### PR DESCRIPTION
## AnimeCardItem component:
  - Clean cover by removing score badge and gradients
  - Unify Type, Score, and Status into compact Pills (same Row)
  - Convert year and episodes into Pills with icons
  - Increase save button to 48dp for better accessibility
  - Adjust title to 1 line and increase size (16sp)
  - Show up to 3 genres instead of 2

 ## Models and data parsing:
  - Add 'type' field to AnimeCardDto and AnimeCard
  - Add 'aired' field to AnimeCardDto for year extraction
  - Create AnimeDataParser.kt with helpers:
    * extractYearFromAired() - extracts year from date strings
    * getDisplayYear() - prioritizes year, fallback to aired
    * getDisplayEpisodes() - smart handling based on type and status
  - Update mappings in GetAnimeSearchUseCase, GetAnimeRandomUseCase, and AnimeRepository

##  New UI components:
  - TypePill, ScorePill, StatusPill - main pills
  - YearPill, EpisodesPill - metadata pills with icons
  - Keep TypeBadge, ScoreChip, StatusBadge for compatibility

##  Layout fixes:
  - Remove hardcoded horizontal padding from LazyColumn
  - Apply padding individually to each element (16dp)
  - Properly align filters and cards
