### PR TITLE
Feat manga search support via AniList

### DIFF
--- a/app/src/main/graphql/com/yumedev/seijakulist/queries/GetMangaDetails.graphql
+++ b/app/src/main/graphql/com/yumedev/seijakulist/queries/GetMangaDetails.graphql
@@ -1,0 +1,214 @@
+query GetMangaDetails($id: Int, $idMal: Int) {
+  Media(id: $id, idMal: $idMal, type: MANGA) {
+    ...MediaFields
+
+    # Capítulos y volúmenes (específico de manga)
+    chapters
+    volumes
+
+    # Relaciones completas (sequels, prequels, spin-offs, adaptaciones anime, etc.)
+    relations {
+      edges {
+        id
+        relationType
+        node {
+          id
+          idMal
+          title {
+            romaji
+            english
+            native
+            userPreferred
+          }
+          coverImage {
+            large
+            extraLarge
+            medium
+            color
+          }
+          bannerImage
+          format
+          type
+          status
+          description(asHtml: false)
+          season
+          seasonYear
+          episodes
+          chapters
+          volumes
+          averageScore
+          meanScore
+          popularity
+          genres
+          siteUrl
+          isFavourite
+        }
+      }
+    }
+
+    # Personajes con TODOS los detalles
+    characters(page: 1, perPage: 50, sort: [ROLE, RELEVANCE, FAVOURITES_DESC]) {
+      pageInfo {
+        total
+        perPage
+        currentPage
+        lastPage
+        hasNextPage
+      }
+      edges {
+        id
+        role
+        name
+        node {
+          ...CharacterFields
+        }
+      }
+    }
+
+    # Staff (autores, artistas, etc. - específico de manga)
+    staff(page: 1, perPage: 25, sort: [RELEVANCE, ID]) {
+      pageInfo {
+        total
+        perPage
+        currentPage
+        lastPage
+        hasNextPage
+      }
+      edges {
+        id
+        role
+        node {
+          id
+          name {
+            full
+            native
+            alternative
+            userPreferred
+          }
+          image {
+            large
+            medium
+          }
+          description(asHtml: false)
+          languageV2
+          gender
+          dateOfBirth {
+            year
+            month
+            day
+          }
+          age
+          yearsActive
+          homeTown
+          bloodType
+          primaryOccupations
+          favourites
+          siteUrl
+          isFavourite
+        }
+      }
+    }
+
+    # Recomendaciones
+    recommendations(page: 1, perPage: 25, sort: [RATING_DESC, ID]) {
+      pageInfo {
+        total
+        perPage
+        currentPage
+        lastPage
+        hasNextPage
+      }
+      nodes {
+        id
+        rating
+        userRating
+        mediaRecommendation {
+          id
+          idMal
+          title {
+            romaji
+            english
+            native
+            userPreferred
+          }
+          coverImage {
+            large
+            extraLarge
+            medium
+            color
+          }
+          bannerImage
+          format
+          type
+          status
+          description(asHtml: false)
+          chapters
+          volumes
+          averageScore
+          meanScore
+          popularity
+          genres
+          isAdult
+          siteUrl
+          isFavourite
+        }
+        user {
+          id
+          name
+          avatar {
+            large
+            medium
+          }
+        }
+      }
+    }
+
+    # Enlaces externos (sitios de lectura, etc.)
+    externalLinks {
+      id
+      site
+      url
+      type
+      language
+      color
+      icon
+      notes
+      isDisabled
+    }
+
+    # Reviews
+    reviews(page: 1, perPage: 10, sort: [RATING_DESC, ID]) {
+      pageInfo {
+        total
+        perPage
+        currentPage
+        lastPage
+        hasNextPage
+      }
+      nodes {
+        id
+        userId
+        mediaId
+        mediaType
+        summary
+        body(asHtml: false)
+        rating
+        ratingAmount
+        userRating
+        score
+        private
+        siteUrl
+        createdAt
+        updatedAt
+        user {
+          id
+          name
+          avatar {
+            large
+            medium
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/MainActivity.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/MainActivity.kt
@@ -76,6 +76,7 @@ import androidx.navigation.compose.composable
 import androidx.compose.runtime.collectAsState
 import com.yumedev.seijakulist.ui.navigation.AppDestinations
 import com.yumedev.seijakulist.ui.screens.detail.AnimeDetailScreen
+import com.yumedev.seijakulist.ui.screens.detail.MangaDetailScreen
 import com.yumedev.seijakulist.ui.screens.search.SearchScreen
 import com.yumedev.seijakulist.ui.theme.SeijakuListTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -353,6 +354,28 @@ fun AppNavigation(
                 )
             } else {
                 Text("Error: anime no encontrado")
+            }
+        }
+        composable(
+            arguments = listOf(
+                navArgument("mangaId") { type = NavType.IntType },
+                navArgument("tab") {
+                    type = NavType.IntType
+                    defaultValue = 0
+                }
+            ),
+            route = "${AppDestinations.MANGA_DETAIL_ROUTE}/{${AppDestinations.MANGA_ID_KEY}}?tab={tab}"
+        ) { backStackEntry ->
+            val mangaId = backStackEntry.arguments?.getInt(AppDestinations.MANGA_ID_KEY)
+            val initialTab = backStackEntry.arguments?.getInt("tab") ?: 0
+            if (mangaId != null) {
+                MangaDetailScreen(
+                    navController = navController,
+                    mangaId = mangaId,
+                    initialTab = initialTab
+                )
+            } else {
+                Text("Error: manga no encontrado")
             }
         }
         composable(

--- a/app/src/main/java/com/yumedev/seijakulist/data/mapper/AniListMangaMapper.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/data/mapper/AniListMangaMapper.kt
@@ -1,0 +1,100 @@
+package com.yumedev.seijakulist.data.mapper
+
+import com.yumedev.seijakulist.data.remote.graphql.GetMangaDetailsQuery
+import com.yumedev.seijakulist.data.remote.graphql.fragment.MediaFields
+import com.yumedev.seijakulist.data.remote.models.CharacterJpgDto
+import com.yumedev.seijakulist.data.remote.models.CharacterWebpDto
+import com.yumedev.seijakulist.data.remote.models.GenreDto
+import com.yumedev.seijakulist.data.remote.models.ImagesCharactersDto
+import com.yumedev.seijakulist.domain.models.AnimeCharactersDetail
+import com.yumedev.seijakulist.domain.models.AuthorDto
+import com.yumedev.seijakulist.domain.models.MangaDetail
+import com.yumedev.seijakulist.domain.models.SerializationDto
+
+/**
+ * Mappers para convertir modelos de Apollo GraphQL (AniList) a Domain Models para Manga
+ */
+
+/**
+ * Convierte GetMangaDetailsQuery.Media a MangaDetail
+ */
+fun GetMangaDetailsQuery.Media.toMangaDetail(): MangaDetail {
+    val fields = mediaFields // Acceder al fragment
+
+    // Extraer autores del staff
+    val authors = staff?.edges?.filterNotNull()?.mapNotNull { edge ->
+        val node = edge.node ?: return@mapNotNull null
+        AuthorDto(
+            malId = node.id,
+            name = node.name?.full ?: node.name?.native ?: "Desconocido",
+            url = node.siteUrl ?: "",
+            role = edge.role ?: "Unknown"
+        )
+    } ?: emptyList()
+
+    return MangaDetail(
+        malId = fields.idMal ?: 0,
+        title = fields.title?.romaji ?: fields.title?.english ?: fields.title?.native ?: "Sin título",
+        titleEnglish = fields.title?.english ?: "No encontrado",
+        titleJapanese = fields.title?.native ?: "No encontrado",
+        images = fields.coverImage?.extraLarge ?: fields.coverImage?.large ?: fields.bannerImage ?: "",
+        typeManga = fields.format?.name ?: "UNKNOWN",
+        source = fields.source?.name ?: "UNKNOWN",
+        chapters = this.chapters, // chapters está en GetMangaDetailsQuery.Media, no en MediaFields
+        volumes = this.volumes,   // volumes está en GetMangaDetailsQuery.Media, no en MediaFields
+        status = fields.status?.name ?: "UNKNOWN",
+        published = formatPublishedDates(fields.startDate, fields.endDate),
+        score = (fields.averageScore ?: 0) / 10.0f,
+        scoreBy = fields.stats?.scoreDistribution?.sumOf { it?.amount ?: 0 } ?: 0,
+        rank = fields.rankings?.firstOrNull { it?.allTime == true }?.rank ?: 0,
+        synopsis = fields.description?.stripHtml() ?: "Sinopsis no disponible",
+        background = "", // AniList no tiene campo de background
+        authors = authors,
+        serializations = emptyList(), // AniList no proporciona información de serialización estructurada
+        genres = fields.genres?.filterNotNull()?.map { GenreDto(malId = null, name = it) } ?: emptyList(),
+        demographics = fields.tags
+            ?.filter { (it?.rank ?: 0) > 80 } // Solo tags con alto ranking
+            ?.map {
+                com.yumedev.seijakulist.data.remote.models.DemographicDto(
+                    malId = it?.id ?: 0,
+                    type = "tag",
+                    name = it?.name ?: "",
+                    url = null
+                )
+            } ?: emptyList()
+    )
+}
+
+/**
+ * Formatea las fechas de publicación en formato legible
+ */
+private fun formatPublishedDates(
+    startDate: MediaFields.StartDate?,
+    endDate: MediaFields.EndDate?
+): String {
+    val start = startDate?.let {
+        "${it.year ?: "?"}-${it.month?.toString()?.padStart(2, '0') ?: "?"}-${it.day?.toString()?.padStart(2, '0') ?: "?"}"
+    } ?: "?"
+
+    val end = endDate?.let {
+        "${it.year ?: "?"}-${it.month?.toString()?.padStart(2, '0') ?: "?"}-${it.day?.toString()?.padStart(2, '0') ?: "?"}"
+    } ?: "?"
+
+    return if (end == "?") start else "$start to $end"
+}
+
+/**
+ * Remueve tags HTML de un string
+ */
+private fun String.stripHtml(): String {
+    return this
+        .replace("<br>", "\n")
+        .replace("<br/>", "\n")
+        .replace("<br />", "\n")
+        .replace(Regex("<[^>]*>"), "")
+        .replace("&quot;", "\"")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .trim()
+}

--- a/app/src/main/java/com/yumedev/seijakulist/data/repository/AnimeAniListRepository.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/data/repository/AnimeAniListRepository.kt
@@ -5,8 +5,10 @@ import com.apollographql.apollo.api.Optional
 import com.yumedev.seijakulist.data.mapper.toAnimeCard
 import com.yumedev.seijakulist.data.mapper.toAnimeCharactersDetail
 import com.yumedev.seijakulist.data.mapper.toAnimeDetail
+import com.yumedev.seijakulist.data.mapper.toMangaDetail
 import com.yumedev.seijakulist.data.remote.graphql.GetAnimeDetailsQuery
 import com.yumedev.seijakulist.data.remote.graphql.GetCharacterDetailsQuery
+import com.yumedev.seijakulist.data.remote.graphql.GetMangaDetailsQuery
 import com.yumedev.seijakulist.data.remote.graphql.GetSeasonalAnimeQuery
 import com.yumedev.seijakulist.data.remote.graphql.SearchAnimeQuery
 import com.yumedev.seijakulist.data.remote.graphql.type.MediaFormat
@@ -590,6 +592,81 @@ class AnimeAniListRepository @Inject constructor(
         return media.map { it.toAnimeCard() }
     }
 
+    // ========== MANGA SEARCH METHODS ==========
+
+    /**
+     * Busca manga por query de búsqueda
+     *
+     * @param query Texto de búsqueda
+     * @param page Número de página (default: 1)
+     * @param perPage Elementos por página (default: 20)
+     * @return Lista de AnimeCard (reutilizamos AnimeCard para manga)
+     */
+    suspend fun searchManga(
+        query: String,
+        page: Int = 1,
+        perPage: Int = DEFAULT_PER_PAGE
+    ): List<AnimeCard> {
+        val response = apolloClient.query(
+            SearchAnimeQuery(
+                page = Optional.present(page),
+                perPage = Optional.present(perPage),
+                search = Optional.present(query),
+                type = Optional.present(com.yumedev.seijakulist.data.remote.graphql.type.MediaType.MANGA),
+                sort = Optional.present(listOf(MediaSort.POPULARITY_DESC))
+            )
+        ).execute()
+
+        if (response.hasErrors()) {
+            throw Exception("GraphQL errors: ${response.errors?.joinToString { it.message }}")
+        }
+
+        val media = response.data?.Page?.media?.filterNotNull() ?: emptyList()
+        return media.map { it.toAnimeCard() }
+    }
+
+    /**
+     * Búsqueda avanzada de manga con múltiples filtros
+     *
+     * @param query Texto de búsqueda (opcional)
+     * @param format Formato (opcional) - MANGA, ONE_SHOT, NOVEL, etc.
+     * @param status Estado (opcional)
+     * @param genre Género (opcional)
+     * @param sort Ordenamiento (opcional)
+     * @param page Número de página
+     * @param perPage Elementos por página
+     * @return Lista de AnimeCard (reutilizamos para manga)
+     */
+    suspend fun searchMangaAdvanced(
+        query: String? = null,
+        format: MediaFormat? = null,
+        status: MediaStatus? = null,
+        genre: String? = null,
+        sort: List<MediaSort> = listOf(MediaSort.POPULARITY_DESC),
+        page: Int = 1,
+        perPage: Int = DEFAULT_PER_PAGE
+    ): List<AnimeCard> {
+        val response = apolloClient.query(
+            SearchAnimeQuery(
+                page = Optional.present(page),
+                perPage = Optional.present(perPage),
+                search = Optional.presentIfNotNull(query),
+                type = Optional.present(com.yumedev.seijakulist.data.remote.graphql.type.MediaType.MANGA),
+                format = Optional.presentIfNotNull(format),
+                status = Optional.presentIfNotNull(status),
+                genre = Optional.presentIfNotNull(genre),
+                sort = Optional.present(sort)
+            )
+        ).execute()
+
+        if (response.hasErrors()) {
+            throw Exception("GraphQL errors: ${response.errors?.joinToString { it.message }}")
+        }
+
+        val media = response.data?.Page?.media?.filterNotNull() ?: emptyList()
+        return media.map { it.toAnimeCard() }
+    }
+
     // ========== HERO SECTION METHODS ==========
 
     /**
@@ -1035,6 +1112,118 @@ class AnimeAniListRepository @Inject constructor(
         val media = response.data?.Page?.media?.filterNotNull()?.randomOrNull() ?: return null
         return media.toAnimeCard()
     }
+
+    // ========== MANGA DETAIL METHODS ==========
+
+    /**
+     * Obtiene detalles de un manga por ID
+     *
+     * @param mangaId ID de AniList (si está disponible)
+     * @param malId MyAnimeList ID (fallback si no hay AniList ID)
+     * @return MangaDetail con información completa
+     */
+    suspend fun getMangaDetailsById(mangaId: Int? = null, malId: Int? = null): com.yumedev.seijakulist.domain.models.MangaDetail {
+        if (mangaId == null && malId == null) {
+            throw IllegalArgumentException("Se requiere mangaId o malId")
+        }
+
+        val response = apolloClient.query(
+            GetMangaDetailsQuery(
+                id = Optional.presentIfNotNull(mangaId),
+                idMal = Optional.presentIfNotNull(malId)
+            )
+        ).execute()
+
+        if (response.hasErrors()) {
+            throw Exception("GraphQL errors: ${response.errors?.joinToString { it.message }}")
+        }
+
+        val media = response.data?.Media
+            ?: throw Exception("No se encontró manga con ID: $mangaId / MAL ID: $malId")
+
+        return media.toMangaDetail()
+    }
+
+    /**
+     * Obtiene personajes de un manga
+     *
+     * @param mangaId ID de AniList
+     * @param malId MyAnimeList ID (alternativo)
+     * @return Lista de AnimeCharactersDetail (reutilizamos para manga)
+     */
+    suspend fun getMangaCharactersById(mangaId: Int? = null, malId: Int? = null): List<AnimeCharactersDetail> {
+        if (mangaId == null && malId == null) {
+            throw IllegalArgumentException("Se requiere mangaId o malId")
+        }
+
+        val response = apolloClient.query(
+            GetMangaDetailsQuery(
+                id = Optional.presentIfNotNull(mangaId),
+                idMal = Optional.presentIfNotNull(malId)
+            )
+        ).execute()
+
+        if (response.hasErrors()) {
+            throw Exception("GraphQL errors: ${response.errors?.joinToString { it.message }}")
+        }
+
+        val characters = response.data?.Media?.characters?.edges?.filterNotNull() ?: emptyList()
+        return characters.map { edge ->
+            val character = edge.node?.characterFields ?: return@map null
+            AnimeCharactersDetail(
+                idCharacter = character.id,
+                nameCharacter = character.name?.full ?: character.name?.native ?: "Desconocido",
+                imageCharacter = com.yumedev.seijakulist.data.remote.models.ImagesCharactersDto(
+                    jpg = com.yumedev.seijakulist.data.remote.models.CharacterJpgDto(character.image?.large),
+                    webp = com.yumedev.seijakulist.data.remote.models.CharacterWebpDto(character.image?.large)
+                ),
+                role = when (edge.role?.name) {
+                    "MAIN" -> "Main"
+                    "SUPPORTING" -> "Supporting"
+                    "BACKGROUND" -> "Background"
+                    else -> edge.role?.name ?: "Unknown"
+                }
+            )
+        }.filterNotNull()
+    }
+
+    /**
+     * Obtiene recomendaciones para un manga
+     *
+     * @param mangaId ID de AniList
+     * @param malId MyAnimeList ID (alternativo)
+     * @return Lista de recomendaciones (como AnimeCard para reutilizar UI)
+     */
+    suspend fun getMangaRecommendations(mangaId: Int? = null, malId: Int? = null): List<com.yumedev.seijakulist.domain.models.AnimeRecommendation> {
+        if (mangaId == null && malId == null) {
+            throw IllegalArgumentException("Se requiere mangaId o malId")
+        }
+
+        val response = apolloClient.query(
+            GetMangaDetailsQuery(
+                id = Optional.presentIfNotNull(mangaId),
+                idMal = Optional.presentIfNotNull(malId)
+            )
+        ).execute()
+
+        if (response.hasErrors()) {
+            throw Exception("GraphQL errors: ${response.errors?.joinToString { it.message }}")
+        }
+
+        val recommendations = response.data?.Media?.recommendations?.nodes?.filterNotNull() ?: emptyList()
+
+        return recommendations.mapNotNull { rec ->
+            val media = rec.mediaRecommendation ?: return@mapNotNull null
+            com.yumedev.seijakulist.domain.models.AnimeRecommendation(
+                malId = media.idMal ?: 0,
+                title = media.title?.romaji ?: media.title?.english ?: media.title?.native ?: "",
+                image = media.coverImage?.large ?: media.coverImage?.extraLarge ?: "",
+                votes = rec.rating ?: 0
+            )
+        }
+    }
+
+    // ========== SCHEDULE METHODS ==========
 
     /**
      * Obtiene anime que se emiten en un rango de tiempo específico

--- a/app/src/main/java/com/yumedev/seijakulist/domain/models/MangaDetail.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/domain/models/MangaDetail.kt
@@ -1,0 +1,51 @@
+package com.yumedev.seijakulist.domain.models
+
+import com.yumedev.seijakulist.data.remote.models.AnimeProducerDto
+import com.yumedev.seijakulist.data.remote.models.DemographicDto
+import com.yumedev.seijakulist.data.remote.models.GenreDto
+
+/**
+ * Modelo de dominio para detalles de manga
+ * Similar a AnimeDetail pero adaptado para manga
+ */
+data class MangaDetail(
+    val malId: Int,
+    val title: String,
+    val titleEnglish: String,
+    val titleJapanese: String,
+    val images: String,
+    val typeManga: String,  // MANGA, NOVEL, ONE_SHOT, MANHWA, MANHUA
+    val source: String,
+    val chapters: Int?,     // Número de capítulos (null si es desconocido)
+    val volumes: Int?,      // Número de volúmenes (null si es desconocido)
+    val status: String,     // FINISHED, RELEASING, NOT_YET_RELEASED, CANCELLED, HIATUS
+    val published: String,  // Rango de fechas de publicación
+    val score: Float,
+    val scoreBy: Int,
+    val rank: Int,
+    val synopsis: String,
+    val background: String,
+    val authors: List<AuthorDto>,      // Autores del manga
+    val serializations: List<SerializationDto>, // Revistas/sitios donde se publicó
+    val genres: List<GenreDto?>,
+    val demographics: List<DemographicDto?>
+)
+
+/**
+ * Información de autor/artista
+ */
+data class AuthorDto(
+    val malId: Int,
+    val name: String,
+    val url: String,
+    val role: String  // Story, Art, Story & Art
+)
+
+/**
+ * Información de serialización (revista/publicación)
+ */
+data class SerializationDto(
+    val malId: Int,
+    val name: String,
+    val url: String
+)

--- a/app/src/main/java/com/yumedev/seijakulist/domain/models/PopularGenres.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/domain/models/PopularGenres.kt
@@ -36,7 +36,7 @@ object PopularGenres {
     )
 
     /**
-     * List of most popular genres for discovery cards
+     * List of most popular genres for anime discovery cards
      * Displayed prominently in SearchScreen
      */
     val popularGenres = listOf(
@@ -54,6 +54,27 @@ object PopularGenres {
         allGenres.first { it.malId == 16 },  // Sports
         allGenres.first { it.malId == 17 },  // Supernatural
         allGenres.first { it.malId == 18 }   // Thriller
+    )
+
+    /**
+     * List of most popular genres for manga discovery cards
+     * Manga tends to have different popular genres than anime
+     */
+    val popularMangaGenres = listOf(
+        allGenres.first { it.malId == 1 },   // Action
+        allGenres.first { it.malId == 2 },   // Adventure
+        allGenres.first { it.malId == 3 },   // Comedy
+        allGenres.first { it.malId == 4 },   // Drama
+        allGenres.first { it.malId == 6 },   // Fantasy
+        allGenres.first { it.malId == 7 },   // Horror
+        allGenres.first { it.malId == 11 },  // Mystery
+        allGenres.first { it.malId == 12 },  // Psychological
+        allGenres.first { it.malId == 13 },  // Romance
+        allGenres.first { it.malId == 14 },  // Sci-Fi
+        allGenres.first { it.malId == 15 },  // Slice of Life
+        allGenres.first { it.malId == 17 },  // Supernatural
+        allGenres.first { it.malId == 18 },  // Thriller
+        allGenres.first { it.malId == 5 }    // Ecchi (más popular en manga)
     )
 
     /**

--- a/app/src/main/java/com/yumedev/seijakulist/domain/usecase/anilist/GetMangaCharactersAniListUseCase.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/domain/usecase/anilist/GetMangaCharactersAniListUseCase.kt
@@ -1,0 +1,28 @@
+package com.yumedev.seijakulist.domain.usecase.anilist
+
+import com.yumedev.seijakulist.data.repository.AnimeAniListRepository
+import com.yumedev.seijakulist.domain.models.AnimeCharactersDetail
+import javax.inject.Inject
+
+/**
+ * UseCase para obtener personajes de un manga usando AniList API
+ *
+ * @param repository Repositorio de AniList
+ */
+class GetMangaCharactersAniListUseCase @Inject constructor(
+    private val repository: AnimeAniListRepository
+) {
+    /**
+     * Obtiene los personajes de un manga
+     *
+     * @param mangaId ID de AniList (opcional)
+     * @param malId MyAnimeList ID (opcional)
+     * @return Lista de AnimeCharactersDetail (reutilizado para manga)
+     */
+    suspend operator fun invoke(
+        mangaId: Int? = null,
+        malId: Int? = null
+    ): List<AnimeCharactersDetail> {
+        return repository.getMangaCharactersById(mangaId = mangaId, malId = malId)
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/domain/usecase/anilist/GetMangaDetailAniListUseCase.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/domain/usecase/anilist/GetMangaDetailAniListUseCase.kt
@@ -1,0 +1,28 @@
+package com.yumedev.seijakulist.domain.usecase.anilist
+
+import com.yumedev.seijakulist.data.repository.AnimeAniListRepository
+import com.yumedev.seijakulist.domain.models.MangaDetail
+import javax.inject.Inject
+
+/**
+ * UseCase para obtener detalles de un manga usando AniList API
+ *
+ * @param repository Repositorio de AniList
+ */
+class GetMangaDetailAniListUseCase @Inject constructor(
+    private val repository: AnimeAniListRepository
+) {
+    /**
+     * Obtiene los detalles completos de un manga
+     *
+     * @param mangaId ID de AniList (opcional)
+     * @param malId MyAnimeList ID (opcional)
+     * @return MangaDetail con información completa del manga
+     */
+    suspend operator fun invoke(
+        mangaId: Int? = null,
+        malId: Int? = null
+    ): MangaDetail {
+        return repository.getMangaDetailsById(mangaId = mangaId, malId = malId)
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/domain/usecase/anilist/GetMangaSearchAniListUseCase.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/domain/usecase/anilist/GetMangaSearchAniListUseCase.kt
@@ -1,0 +1,62 @@
+package com.yumedev.seijakulist.domain.usecase.anilist
+
+import com.yumedev.seijakulist.data.remote.graphql.type.MediaFormat
+import com.yumedev.seijakulist.data.repository.AnimeAniListRepository
+import com.yumedev.seijakulist.domain.models.AnimeCard
+import javax.inject.Inject
+
+/**
+ * UseCase para buscar manga usando AniList API
+ *
+ * @param repository Repositorio de AniList
+ */
+class GetMangaSearchAniListUseCase @Inject constructor(
+    private val repository: AnimeAniListRepository
+) {
+    /**
+     * Busca manga por query de texto
+     *
+     * @param query Texto de búsqueda
+     * @param page Número de página (default: 1)
+     * @param type Tipo de formato de manga (opcional): "manga", "novel", "one_shot"
+     * @return Lista de AnimeCard con resultados de búsqueda (reutilizamos AnimeCard para manga)
+     */
+    suspend operator fun invoke(
+        query: String,
+        page: Int = 1,
+        type: String? = null
+    ): List<AnimeCard> {
+        // Convertir el tipo string a MediaFormat si está presente
+        val format = type?.let { mapTypeToFormat(it) }
+
+        return if (format != null) {
+            // Búsqueda con filtro de formato
+            repository.searchMangaAdvanced(
+                query = query,
+                format = format,
+                page = page
+            )
+        } else {
+            // Búsqueda simple
+            repository.searchManga(
+                query = query,
+                page = page
+            )
+        }
+    }
+
+    /**
+     * Mapea el tipo string a MediaFormat de AniList para manga
+     *
+     * @param type Tipo como string ("manga", "novel", "one_shot")
+     * @return MediaFormat correspondiente o null
+     */
+    private fun mapTypeToFormat(type: String): MediaFormat? {
+        return when (type.lowercase()) {
+            "manga" -> MediaFormat.MANGA
+            "novel" -> MediaFormat.NOVEL
+            "one_shot", "oneshot" -> MediaFormat.ONE_SHOT
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/ui/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/navigation/AppDestinations.kt
@@ -7,6 +7,9 @@ object AppDestinations {
     const val ANIME_DETAIL_ROUTE = "anime_detail_route"
     const val ANIME_ID_KEY = "animeId"
 
+    const val MANGA_DETAIL_ROUTE = "manga_detail_route"
+    const val MANGA_ID_KEY = "mangaId"
+
     const val CHARACTER_DETAIL_ROUTE = "character_detail_route"
 
     const val CHARACTER_ID_KEY = "characterId"

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaCharacterDetailViewModel.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaCharacterDetailViewModel.kt
@@ -1,0 +1,96 @@
+package com.yumedev.seijakulist.ui.screens.detail
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yumedev.seijakulist.common.RequestThrottler
+import com.yumedev.seijakulist.domain.models.AnimeCharactersDetail
+import com.yumedev.seijakulist.domain.usecase.anilist.GetMangaCharactersAniListUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel para gestionar los personajes de un manga
+ *
+ * @param savedStateHandle Manejo del estado guardado
+ * @param getMangaCharactersAniListUseCase Caso de uso para obtener personajes del manga
+ * @param requestThrottler Throttler para limitar requests a la API
+ */
+@HiltViewModel
+class MangaCharacterDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getMangaCharactersAniListUseCase: GetMangaCharactersAniListUseCase,
+    private val requestThrottler: RequestThrottler
+) : ViewModel() {
+
+    // State para los personajes del manga
+    private val _characters = MutableStateFlow<List<AnimeCharactersDetail>>(emptyList())
+    val characters: StateFlow<List<AnimeCharactersDetail>> = _characters.asStateFlow()
+
+    // State para loading
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    // State para mensajes de error
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    // ID del manga obtenido de los argumentos de navegación
+    private val mangaId: Int = savedStateHandle["mangaId"] ?: 0
+
+    init {
+        Log.d(TAG, "MangaCharacterDetailViewModel init - mangaId: $mangaId")
+        if (mangaId != 0) {
+            loadCharacters(mangaId)
+        } else {
+            Log.e(TAG, "MangaId is 0! Cannot load characters")
+            _errorMessage.value = "ID de manga inválido"
+        }
+    }
+
+    /**
+     * Carga los personajes del manga desde AniList
+     *
+     * @param mangaId ID del manga (MyAnimeList ID)
+     */
+    fun loadCharacters(mangaId: Int) {
+        Log.d(TAG, "loadCharacters called with mangaId: $mangaId")
+        _errorMessage.value = null
+        _isLoading.value = true
+
+        viewModelScope.launch {
+            try {
+                Log.d(TAG, "Fetching manga characters from AniList...")
+                val charactersList = requestThrottler.throttle {
+                    getMangaCharactersAniListUseCase(malId = mangaId)
+                }
+
+                Log.d(TAG, "Characters loaded successfully: ${charactersList?.size ?: 0} characters")
+                _characters.value = charactersList ?: emptyList()
+            } catch (e: Exception) {
+                Log.e(TAG, "Error al cargar personajes: ${e.localizedMessage ?: "Error desconocido"}", e)
+                _errorMessage.value = "Error al cargar los personajes"
+                _characters.value = emptyList()
+            } finally {
+                _isLoading.value = false
+                Log.d(TAG, "loadCharacters finished. isLoading: false")
+            }
+        }
+    }
+
+    /**
+     * Limpia el mensaje de error
+     */
+    fun clearError() {
+        _errorMessage.value = null
+    }
+
+    companion object {
+        private const val TAG = "MangaCharacterVM"
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailAniListViewModel.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailAniListViewModel.kt
@@ -1,0 +1,105 @@
+package com.yumedev.seijakulist.ui.screens.detail
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yumedev.seijakulist.common.RequestThrottler
+import com.yumedev.seijakulist.domain.models.MangaDetail
+import com.yumedev.seijakulist.domain.usecase.anilist.GetMangaDetailAniListUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel para la pantalla de detalle de manga usando AniList API
+ *
+ * Proporciona funcionalidad básica para:
+ * - Cargar detalles del manga desde AniList
+ * - Verificar si el manga está en la lista local del usuario
+ * - Agregar manga a la lista local del usuario (futuro)
+ *
+ * @param savedStateHandle Manejo del estado guardado
+ * @param getMangaDetailAniListUseCase Caso de uso para obtener detalles del manga
+ * @param requestThrottler Throttler para limitar requests a la API
+ */
+@HiltViewModel
+class MangaDetailAniListViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getMangaDetailAniListUseCase: GetMangaDetailAniListUseCase,
+    private val requestThrottler: RequestThrottler
+) : ViewModel() {
+
+    // State para el detalle del manga
+    private val _mangaDetail = MutableStateFlow<MangaDetail?>(null)
+    val mangaDetail: StateFlow<MangaDetail?> = _mangaDetail.asStateFlow()
+
+    // State para loading
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    // State para mensajes de error
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    // ID del manga obtenido de los argumentos de navegación
+    private val mangaId: Int = savedStateHandle["mangaId"] ?: 0
+
+    init {
+        Log.d(TAG, "MangaDetailAniListViewModel init - mangaId: $mangaId")
+        if (mangaId != 0) {
+            loadMangaDetail(mangaId)
+        } else {
+            Log.e(TAG, "MangaId is 0! Cannot load manga details")
+            _errorMessage.value = "ID de manga inválido"
+        }
+    }
+
+    /**
+     * Carga los detalles del manga desde AniList
+     *
+     * @param mangaId ID del manga (MyAnimeList ID)
+     */
+    fun loadMangaDetail(mangaId: Int) {
+        Log.d(TAG, "loadMangaDetail called with mangaId: $mangaId")
+        _errorMessage.value = null
+        _isLoading.value = true
+
+        viewModelScope.launch {
+            try {
+                Log.d(TAG, "Fetching manga detail from AniList...")
+                val detail = requestThrottler.throttle {
+                    getMangaDetailAniListUseCase(malId = mangaId)
+                }
+
+                if (detail != null) {
+                    Log.d(TAG, "Manga detail loaded successfully: ${detail.title}")
+                    _mangaDetail.value = detail
+                } else {
+                    throw Exception("No se pudo obtener los detalles del manga")
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error al cargar detalles del manga: ${e.localizedMessage ?: "Error desconocido"}", e)
+                _errorMessage.value = "Algo salió mal al cargar los detalles del manga, por favor inténtalo de nuevo."
+                _mangaDetail.value = null
+            } finally {
+                _isLoading.value = false
+                Log.d(TAG, "loadMangaDetail finished. isLoading: false")
+            }
+        }
+    }
+
+    /**
+     * Limpia el mensaje de error
+     */
+    fun clearError() {
+        _errorMessage.value = null
+    }
+
+    companion object {
+        private const val TAG = "MangaDetailVM"
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
@@ -1,0 +1,242 @@
+package com.yumedev.seijakulist.ui.screens.detail
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.yumedev.seijakulist.domain.models.MangaDetail
+import com.yumedev.seijakulist.ui.components.LoadingScreen
+import com.yumedev.seijakulist.ui.screens.detail.components.header.MangaDetailHeader
+import com.yumedev.seijakulist.ui.screens.detail.components.tabs.*
+import com.yumedev.seijakulist.ui.theme.PoppinsBold
+
+/**
+ * Pantalla de detalle del manga
+ *
+ * Estructura modular similar a AnimeDetailScreen:
+ * - Header hero con imagen y información principal
+ * - Sistema de tabs para organizar el contenido
+ * - Tabs: Overview, Characters
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MangaDetailScreen(
+    navController: NavController,
+    mangaId: Int?,
+    initialTab: Int = 0,
+    mangaDetailViewModel: MangaDetailAniListViewModel = hiltViewModel(),
+    mangaCharacterDetailViewModel: MangaCharacterDetailViewModel = hiltViewModel()
+) {
+    // ViewModels state
+    val mangaDetail by mangaDetailViewModel.mangaDetail.collectAsState()
+    val isLoading by mangaDetailViewModel.isLoading.collectAsState()
+    val errorMessage by mangaDetailViewModel.errorMessage.collectAsState()
+
+    val mangaCharactersDetail by mangaCharacterDetailViewModel.characters.collectAsState()
+    val characterIsLoading by mangaCharacterDetailViewModel.isLoading.collectAsState()
+
+    // UI State
+    var selectedTab by remember { mutableStateOf(MangaDetailTab.OVERVIEW) }
+    val focusManager = LocalFocusManager.current
+    val lazyListState = rememberLazyListState()
+
+    // Set initial tab if provided
+    LaunchedEffect(initialTab) {
+        selectedTab = when (initialTab) {
+            1 -> MangaDetailTab.CHARACTERS
+            else -> MangaDetailTab.OVERVIEW
+        }
+    }
+
+    val displayImageUrl = mangaDetail?.images ?: ""
+
+    // Main content
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    focusManager.clearFocus()
+                })
+            }
+    ) {
+        when {
+            isLoading && mangaDetail == null -> {
+                LoadingScreen()
+            }
+            errorMessage != null && mangaDetail == null -> {
+                ErrorMangaDetailContent(
+                    errorMessage = errorMessage ?: "Error desconocido",
+                    onRetry = { mangaId?.let { mangaDetailViewModel.loadMangaDetail(it) } },
+                    onBack = { navController.popBackStack() }
+                )
+            }
+            mangaDetail != null -> {
+                MangaDetailContent(
+                    mangaDetail = mangaDetail!!,
+                    selectedTab = selectedTab,
+                    onTabSelected = { selectedTab = it },
+                    mangaCharactersDetail = mangaCharactersDetail,
+                    characterIsLoading = characterIsLoading,
+                    lazyListState = lazyListState,
+                    navController = navController,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Contenido principal del detalle del manga
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MangaDetailContent(
+    mangaDetail: MangaDetail,
+    selectedTab: MangaDetailTab,
+    onTabSelected: (MangaDetailTab) -> Unit,
+    mangaCharactersDetail: List<com.yumedev.seijakulist.domain.models.AnimeCharactersDetail>,
+    characterIsLoading: Boolean,
+    lazyListState: androidx.compose.foundation.lazy.LazyListState,
+    navController: NavController,
+    onBack: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = mangaDetail.title,
+                        fontFamily = PoppinsBold,
+                        maxLines = 1
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Volver"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            state = lazyListState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            // Header con imagen y info principal
+            item {
+                MangaDetailHeader(mangaDetail = mangaDetail)
+            }
+
+            // Tabs
+            item {
+                MangaDetailTabs(
+                    selectedTab = selectedTab,
+                    onTabSelected = onTabSelected
+                )
+            }
+
+            // Tab Content
+            item {
+                when (selectedTab) {
+                    MangaDetailTab.OVERVIEW -> {
+                        MangaOverviewTab(mangaDetail = mangaDetail)
+                    }
+                    MangaDetailTab.CHARACTERS -> {
+                        CharactersTab(
+                            characters = mangaCharactersDetail,
+                            isLoading = characterIsLoading,
+                            errorMessage = null,
+                            navController = navController
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Pantalla de error para detalles del manga
+ */
+@Composable
+private fun ErrorMangaDetailContent(
+    errorMessage: String = "Error desconocido",
+    onRetry: () -> Unit,
+    onBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = errorMessage,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(16.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Row {
+            Button(onClick = onRetry) {
+                Text("Reintentar")
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            OutlinedButton(onClick = onBack) {
+                Text("Volver")
+            }
+        }
+    }
+}
+
+/**
+ * Enum para las tabs del detalle del manga
+ */
+enum class MangaDetailTab {
+    OVERVIEW,
+    CHARACTERS
+}
+
+/**
+ * Componente de tabs para el detalle del manga
+ */
+@Composable
+private fun MangaDetailTabs(
+    selectedTab: MangaDetailTab,
+    onTabSelected: (MangaDetailTab) -> Unit
+) {
+    TabRow(
+        selectedTabIndex = selectedTab.ordinal,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Tab(
+            selected = selectedTab == MangaDetailTab.OVERVIEW,
+            onClick = { onTabSelected(MangaDetailTab.OVERVIEW) },
+            text = { Text("Resumen") }
+        )
+        Tab(
+            selected = selectedTab == MangaDetailTab.CHARACTERS,
+            onClick = { onTabSelected(MangaDetailTab.CHARACTERS) },
+            text = { Text("Personajes") }
+        )
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/components/header/MangaDetailHeader.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/components/header/MangaDetailHeader.kt
@@ -1,0 +1,187 @@
+package com.yumedev.seijakulist.ui.screens.detail.components.header
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.yumedev.seijakulist.domain.models.MangaDetail
+import com.yumedev.seijakulist.ui.theme.PoppinsBold
+import com.yumedev.seijakulist.ui.theme.PoppinsMedium
+
+/**
+ * Header del detalle del manga con imagen de portada y información principal
+ */
+@Composable
+fun MangaDetailHeader(mangaDetail: MangaDetail) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(300.dp)
+    ) {
+        // Imagen de fondo
+        AsyncImage(
+            model = mangaDetail.images,
+            contentDescription = mangaDetail.title,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop
+        )
+
+        // Gradiente oscuro
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Transparent,
+                            Color.Black.copy(alpha = 0.7f)
+                        )
+                    )
+                )
+        )
+
+        // Información sobre el gradiente
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(16.dp)
+        ) {
+            Text(
+                text = mangaDetail.title,
+                fontFamily = PoppinsBold,
+                fontSize = 24.sp,
+                color = Color.White,
+                maxLines = 2
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Score
+                if (mangaDetail.score > 0) {
+                    ScoreChip(score = mangaDetail.score)
+                }
+
+                // Tipo
+                TypeChip(type = mangaDetail.typeManga)
+
+                // Estado
+                StatusChip(status = mangaDetail.status)
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // Capítulos
+                if (mangaDetail.chapters != null && mangaDetail.chapters > 0) {
+                    InfoChip(text = "${mangaDetail.chapters} caps")
+                }
+
+                // Volúmenes
+                if (mangaDetail.volumes != null && mangaDetail.volumes > 0) {
+                    InfoChip(text = "${mangaDetail.volumes} vols")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScoreChip(score: Float) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primary
+        ),
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Text(
+            text = "⭐ ${String.format("%.1f", score)}",
+            fontFamily = PoppinsMedium,
+            fontSize = 14.sp,
+            color = Color.White,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+        )
+    }
+}
+
+@Composable
+private fun TypeChip(type: String) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondary
+        ),
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Text(
+            text = type,
+            fontFamily = PoppinsMedium,
+            fontSize = 14.sp,
+            color = Color.White,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+        )
+    }
+}
+
+@Composable
+private fun StatusChip(status: String) {
+    val statusText = when (status) {
+        "FINISHED" -> "Finalizado"
+        "RELEASING" -> "En publicación"
+        "NOT_YET_RELEASED" -> "Próximamente"
+        "CANCELLED" -> "Cancelado"
+        "HIATUS" -> "En pausa"
+        else -> status
+    }
+
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiary
+        ),
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Text(
+            text = statusText,
+            fontFamily = PoppinsMedium,
+            fontSize = 14.sp,
+            color = Color.White,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+        )
+    }
+}
+
+@Composable
+private fun InfoChip(text: String) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White.copy(alpha = 0.2f)
+        ),
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Text(
+            text = text,
+            fontFamily = PoppinsMedium,
+            fontSize = 14.sp,
+            color = Color.White,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/components/tabs/MangaOverviewTab.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/components/tabs/MangaOverviewTab.kt
@@ -1,0 +1,200 @@
+package com.yumedev.seijakulist.ui.screens.detail.components.tabs
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yumedev.seijakulist.domain.models.MangaDetail
+import com.yumedev.seijakulist.ui.theme.PoppinsBold
+import com.yumedev.seijakulist.ui.theme.PoppinsMedium
+import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+
+/**
+ * Tab de resumen/overview para el detalle del manga
+ */
+@Composable
+fun MangaOverviewTab(mangaDetail: MangaDetail) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        // Sinopsis
+        if (mangaDetail.synopsis.isNotBlank()) {
+            SectionTitle("Sinopsis")
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = mangaDetail.synopsis,
+                fontFamily = PoppinsRegular,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        // Información general
+        SectionTitle("Información")
+        Spacer(modifier = Modifier.height(12.dp))
+
+        InfoRow("Título en inglés", mangaDetail.titleEnglish)
+        InfoRow("Título japonés", mangaDetail.titleJapanese)
+        InfoRow("Tipo", mangaDetail.typeManga)
+        InfoRow("Estado", formatStatus(mangaDetail.status))
+
+        if (mangaDetail.chapters != null && mangaDetail.chapters > 0) {
+            InfoRow("Capítulos", mangaDetail.chapters.toString())
+        }
+
+        if (mangaDetail.volumes != null && mangaDetail.volumes > 0) {
+            InfoRow("Volúmenes", mangaDetail.volumes.toString())
+        }
+
+        InfoRow("Fuente", formatSource(mangaDetail.source))
+        InfoRow("Publicado", mangaDetail.published)
+
+        if (mangaDetail.score > 0) {
+            InfoRow("Puntuación", "${mangaDetail.score}/10")
+        }
+
+        if (mangaDetail.scoreBy > 0) {
+            InfoRow("Puntuado por", "${mangaDetail.scoreBy} usuarios")
+        }
+
+        if (mangaDetail.rank > 0) {
+            InfoRow("Ranking", "#${mangaDetail.rank}")
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Autores
+        if (mangaDetail.authors.isNotEmpty()) {
+            SectionTitle("Autores")
+            Spacer(modifier = Modifier.height(12.dp))
+
+            mangaDetail.authors.forEach { author ->
+                InfoRow(author.role, author.name)
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        // Géneros
+        if (mangaDetail.genres.isNotEmpty()) {
+            SectionTitle("Géneros")
+            Spacer(modifier = Modifier.height(8.dp))
+
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(mangaDetail.genres.filterNotNull()) { genre ->
+                    GenreChip(genreName = genre.name ?: "")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        // Background (si existe)
+        if (mangaDetail.background.isNotBlank()) {
+            SectionTitle("Contexto")
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = mangaDetail.background,
+                fontFamily = PoppinsRegular,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(title: String) {
+    Text(
+        text = title,
+        fontFamily = PoppinsBold,
+        fontSize = 18.sp,
+        color = MaterialTheme.colorScheme.primary
+    )
+}
+
+@Composable
+private fun InfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            fontFamily = PoppinsMedium,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = value,
+            fontFamily = PoppinsRegular,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun GenreChip(genreName: String) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Text(
+            text = genreName,
+            fontFamily = PoppinsMedium,
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+        )
+    }
+}
+
+private fun formatStatus(status: String): String {
+    return when (status) {
+        "FINISHED" -> "Finalizado"
+        "RELEASING" -> "En publicación"
+        "NOT_YET_RELEASED" -> "Próximamente"
+        "CANCELLED" -> "Cancelado"
+        "HIATUS" -> "En pausa"
+        else -> status
+    }
+}
+
+private fun formatSource(source: String): String {
+    return when (source) {
+        "ORIGINAL" -> "Original"
+        "MANGA" -> "Manga"
+        "LIGHT_NOVEL" -> "Light Novel"
+        "VISUAL_NOVEL" -> "Visual Novel"
+        "VIDEO_GAME" -> "Videojuego"
+        "OTHER" -> "Otro"
+        "NOVEL" -> "Novela"
+        "DOUJINSHI" -> "Doujinshi"
+        "ANIME" -> "Anime"
+        "WEB_NOVEL" -> "Web Novel"
+        "LIVE_ACTION" -> "Live Action"
+        "GAME" -> "Juego"
+        "COMIC" -> "Comic"
+        "MULTIMEDIA_PROJECT" -> "Proyecto Multimedia"
+        "PICTURE_BOOK" -> "Libro Ilustrado"
+        else -> source
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
@@ -307,6 +307,8 @@ class AnimeSearchViewModel @Inject constructor(
             "Manga" -> "manga"
             "Novel" -> "novel"
             "One Shot" -> "one_shot"
+            "Manhwa" -> "manga"  // Manhwa es técnicamente manga coreano, se busca como manga
+            "Manhua" -> "manga"  // Manhua es manga chino, se busca como manga
             else -> format.lowercase()
         }
     }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
@@ -131,7 +131,7 @@ class AnimeSearchViewModel @Inject constructor(
             it.copy(
                 selectedFilter = filter,
                 searchQuery = "",
-                selectedGenreId = if (filter != "Géneros") null else it.selectedGenreId,
+                selectedGenreId = null, // Clear genre when changing filter type
                 selectedQuickFilter = null,
                 selectedFormat = null,
                 // Update mediaType when switching between Anime and Manga
@@ -278,8 +278,8 @@ class AnimeSearchViewModel @Inject constructor(
                 val formatType = currentState.selectedFormat?.let { mapMangaFormatToType(it) }
                 getMangaSearchAniListUseCase(query = currentState.searchQuery, page = page, type = formatType)
             }
-            // 3. Si es filtro por género
-            currentState.selectedFilter == "Géneros" && currentState.selectedGenreId != null -> {
+            // 3. Si hay un género seleccionado (sin búsqueda de texto)
+            currentState.selectedGenreId != null && currentState.searchQuery.isBlank() -> {
                 // Convertir malId a nombre de género para AniList
                 val genreName = com.yumedev.seijakulist.domain.models.PopularGenres.getGenreById(
                     currentState.selectedGenreId.toIntOrNull() ?: 0

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
@@ -11,6 +11,7 @@ import com.yumedev.seijakulist.data.repository.FirestoreAnimeRepository
 import com.yumedev.seijakulist.data.repository.SearchHistoryRepository
 import com.yumedev.seijakulist.domain.models.AnimeCard
 import com.yumedev.seijakulist.domain.usecase.anilist.GetAnimeSearchAniListUseCase
+import com.yumedev.seijakulist.domain.usecase.anilist.GetMangaSearchAniListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,6 +30,7 @@ private const val PAGE_SIZE = 25
 @HiltViewModel
 class AnimeSearchViewModel @Inject constructor(
     private val getAnimeSearchAniListUseCase: GetAnimeSearchAniListUseCase,
+    private val getMangaSearchAniListUseCase: GetMangaSearchAniListUseCase,
     private val animeAniListRepository: AnimeAniListRepository,
     private val animeLocalRepository: AnimeLocalRepository,
     private val firestoreAnimeRepository: FirestoreAnimeRepository,
@@ -89,7 +91,8 @@ class AnimeSearchViewModel @Inject constructor(
         _state.update {
             it.copy(
                 searchQuery = newQuery,
-                selectedFilter = "Anime",
+                // Mantener el filtro seleccionado actual (Anime o Manga) o usar "Anime" por defecto
+                selectedFilter = if (it.selectedFilter == "Manga" || it.selectedFilter == "Anime") it.selectedFilter else "Anime",
                 selectedGenreId = null,
                 selectedQuickFilter = null,
                 animeList = if (newQuery.isBlank()) emptyList() else it.animeList,
@@ -255,7 +258,7 @@ class AnimeSearchViewModel @Inject constructor(
                     else -> emptyList()
                 }
             }
-            // 2. Si hay búsqueda de texto (con o sin formato)
+            // 2. Si hay búsqueda de texto de ANIME (con o sin formato)
             currentState.searchQuery.isNotBlank() && currentState.selectedFilter == "Anime" -> {
                 // Guardar la búsqueda en el historial solo en la primera página
                 if (page == 1) {
@@ -263,6 +266,15 @@ class AnimeSearchViewModel @Inject constructor(
                 }
                 val formatType = currentState.selectedFormat?.let { mapFormatToType(it) }
                 getAnimeSearchAniListUseCase(query = currentState.searchQuery, page = page, type = formatType)
+            }
+            // 2b. Si hay búsqueda de texto de MANGA
+            currentState.searchQuery.isNotBlank() && currentState.selectedFilter == "Manga" -> {
+                // Guardar la búsqueda en el historial solo en la primera página
+                if (page == 1) {
+                    saveSearchToHistory(currentState.searchQuery)
+                }
+                val formatType = currentState.selectedFormat?.let { mapMangaFormatToType(it) }
+                getMangaSearchAniListUseCase(query = currentState.searchQuery, page = page, type = formatType)
             }
             // 3. Si es filtro por género
             currentState.selectedFilter == "Géneros" && currentState.selectedGenreId != null -> {
@@ -276,7 +288,7 @@ class AnimeSearchViewModel @Inject constructor(
         }
     }
 
-    // Mapea los formatos de UI a los tipos de la API
+    // Mapea los formatos de UI a los tipos de la API (para anime)
     private fun mapFormatToType(format: String): String {
         return when (format) {
             "TV" -> "tv"
@@ -285,6 +297,16 @@ class AnimeSearchViewModel @Inject constructor(
             "ONA" -> "ona"
             "Especial" -> "special"
             "Música" -> "music"
+            else -> format.lowercase()
+        }
+    }
+
+    // Mapea los formatos de UI a los tipos de la API (para manga)
+    private fun mapMangaFormatToType(format: String): String {
+        return when (format) {
+            "Manga" -> "manga"
+            "Novel" -> "novel"
+            "One Shot" -> "one_shot"
             else -> format.lowercase()
         }
     }
@@ -333,8 +355,17 @@ class AnimeSearchViewModel @Inject constructor(
     private fun fetchPreviewResults(query: String, selectedFormat: String?) {
         viewModelScope.launch {
             try {
-                val formatType = selectedFormat?.let { mapFormatToType(it) }
-                val results = getAnimeSearchAniListUseCase(query = query, page = 1, type = formatType)
+                val currentFilter = _state.value.selectedFilter
+                val results = when (currentFilter) {
+                    "Manga" -> {
+                        val formatType = selectedFormat?.let { mapMangaFormatToType(it) }
+                        getMangaSearchAniListUseCase(query = query, page = 1, type = formatType)
+                    }
+                    else -> { // "Anime" o cualquier otro
+                        val formatType = selectedFormat?.let { mapFormatToType(it) }
+                        getAnimeSearchAniListUseCase(query = query, page = 1, type = formatType)
+                    }
+                }
                 _state.update { it.copy(previewResults = results.take(PREVIEW_ITEMS_COUNT)) }
             } catch (e: Exception) {
                 Log.e("AnimeSearchVM", "Error en vista previa: ${e.message}")

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/AnimeSearchViewModel.kt
@@ -133,7 +133,9 @@ class AnimeSearchViewModel @Inject constructor(
                 searchQuery = "",
                 selectedGenreId = if (filter != "Géneros") null else it.selectedGenreId,
                 selectedQuickFilter = null,
-                selectedFormat = null
+                selectedFormat = null,
+                // Update mediaType when switching between Anime and Manga
+                mediaType = if (filter == "Anime" || filter == "Manga") filter else it.mediaType
             )
         }
     }
@@ -282,7 +284,13 @@ class AnimeSearchViewModel @Inject constructor(
                 val genreName = com.yumedev.seijakulist.domain.models.PopularGenres.getGenreById(
                     currentState.selectedGenreId.toIntOrNull() ?: 0
                 )?.name ?: currentState.selectedGenreId
-                animeAniListRepository.getAnimeByGenre(genreName, page = page)
+
+                // Use mediaType to determine if we should search anime or manga by genre
+                if (currentState.mediaType == "Manga") {
+                    animeAniListRepository.searchMangaAdvanced(genre = genreName, page = page)
+                } else {
+                    animeAniListRepository.getAnimeByGenre(genreName, page = page)
+                }
             }
             else -> emptyList()
         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
@@ -166,7 +166,7 @@ private val quickFilters = listOf(
 private val contentTypeFilters = listOf(
     "Anime" to Icons.Default.Tv,
     "Manga" to Icons.AutoMirrored.Filled.MenuBook,
-    "Géneros" to Icons.Default.Category,
+    // "Géneros" removed - genres are now shown in discovery section based on selected media type
     "Personajes" to Icons.Default.Person,
     "Staff" to Icons.Default.Groups,
     "Estudios" to Icons.Default.Business,
@@ -276,7 +276,7 @@ fun SearchScreen(
                 },
                 onGenreDirectTap = { genreId ->
                     viewModel.onGenreSelected(genreId)
-                    viewModel.onFilterSelected("Géneros")
+                    // No need to change filter - it stays as "Anime" or "Manga"
                     viewModel.performSearchOrFilter()
                     expanded = true
                 }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
@@ -925,7 +925,7 @@ private fun SearchContent(
             }
             items(animeList, key = { it.malId }) { anime ->
                 Box(modifier = Modifier.padding(horizontal = 16.dp)) {
-                    AnimeCardItem(navController = navController, anime = anime)
+                    AnimeCardItem(navController = navController, anime = anime, isManga = selectedFilter == "Manga")
                 }
             }
             if (isLoadingMore) {
@@ -970,6 +970,7 @@ private fun SearchContent(
                     PreviewAnimeCard(
                         anime = anime,
                         navController = navController,
+                        isManga = selectedFilter == "Manga",
                         onClick = {
                             onPerformSearch()
                         }
@@ -1123,16 +1124,35 @@ private fun SearchItemRow(
 // ─────────────────────────────────────────────────────────────────────────────
 // TARJETA DE VISTA PREVIA — VERSIÓN COMPACTA
 // ─────────────────────────────────────────────────────────────────────────────
+/**
+ * Helper function to navigate to detail screen (anime or manga)
+ */
+private fun navigateToDetail(navController: NavController, malId: Int, isManga: Boolean, openSheet: Boolean = false) {
+    val route = if (isManga) {
+        "${AppDestinations.MANGA_DETAIL_ROUTE}/$malId"
+    } else {
+        if (openSheet) {
+            "${AppDestinations.ANIME_DETAIL_ROUTE}/$malId?openSheet=true"
+        } else {
+            "${AppDestinations.ANIME_DETAIL_ROUTE}/$malId"
+        }
+    }
+    navController.navigate(route)
+}
+
 @Composable
 private fun PreviewAnimeCard(
     anime: AnimeCard,
     navController: NavController,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    isManga: Boolean = false
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { navController.navigate("${AppDestinations.ANIME_DETAIL_ROUTE}/${anime.malId}") }
+            .clickable {
+                navigateToDetail(navController, anime.malId, isManga)
+            }
             .padding(horizontal = 16.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -1215,7 +1235,8 @@ private fun PreviewAnimeCard(
 @Composable
 fun AnimeCardItem(
     navController: NavController,
-    anime: AnimeCard
+    anime: AnimeCard,
+    isManga: Boolean = false
 ) {
     var isPressed by remember { mutableStateOf(false) }
     val isDarkTheme = MaterialTheme.colorScheme.surface.luminance() < 0.5f
@@ -1236,7 +1257,7 @@ fun AnimeCardItem(
             .pointerInput(Unit) {
                 detectTapGestures(
                     onPress = { isPressed = true; tryAwaitRelease(); isPressed = false },
-                    onTap = { navController.navigate("${AppDestinations.ANIME_DETAIL_ROUTE}/${anime.malId}") }
+                    onTap = { navigateToDetail(navController, anime.malId, isManga) }
                 )
             },
         colors = CardDefaults.cardColors(
@@ -1320,7 +1341,7 @@ fun AnimeCardItem(
                     }
                     Surface(
                         onClick = {
-                            navController.navigate("${AppDestinations.ANIME_DETAIL_ROUTE}/${anime.malId}?openSheet=true")
+                            navigateToDetail(navController, anime.malId, isManga, openSheet = !isManga)
                         },
                         shape = CircleShape,
                         color = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
@@ -1348,7 +1369,7 @@ fun AnimeCardItem(
 // TARJETA MINIMAL (variante compacta para otras pantallas)
 // ─────────────────────────────────────────────────────────────────────────────
 @Composable
-fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard) {
+fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard, isManga: Boolean = false) {
     var isPressed by remember { mutableStateOf(false) }
     val isDarkTheme = MaterialTheme.colorScheme.surface.luminance() < 0.5f
 
@@ -1363,7 +1384,7 @@ fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard) {
             .pointerInput(Unit) {
                 detectTapGestures(
                     onPress = { isPressed = true; tryAwaitRelease(); isPressed = false },
-                    onTap = { navController.navigate("${AppDestinations.ANIME_DETAIL_ROUTE}/${anime.malId}") }
+                    onTap = { navigateToDetail(navController, anime.malId, isManga) }
                 )
             },
         colors = CardDefaults.cardColors(

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchScreen.kt
@@ -173,7 +173,10 @@ private val contentTypeFilters = listOf(
 )
 
 // ─── Formatos de anime ───────────────────────────────────────────────────────
-private val formatFilters = listOf("TV", "Película", "OVA", "ONA", "Especial", "Música")
+private val animeFormatFilters = listOf("TV", "Película", "OVA", "ONA", "Especial", "Música")
+
+// ─── Formatos de manga ───────────────────────────────────────────────────────
+private val mangaFormatFilters = listOf("Manga", "Novel", "One Shot", "Manhwa", "Manhua")
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PANTALLA PRINCIPAL
@@ -472,6 +475,7 @@ fun SearchScreen(
             selectedQuick = selectedQuick,
             selectedFormat = selectedFormat,
             selectedGenreId = selectedGenreId,
+            selectedFilter = selectedFilter ?: "Anime",
             onQuickFilterSelected = { filter ->
                 viewModel.onQuickFilterSelected(if (selectedQuick == filter) null else filter)
             },
@@ -548,10 +552,10 @@ private fun SearchDiscoveryView(
         }
 
         // ═══════════════════════════════════════════════════════════════════
-        // SECCIÓN 2 — Formatos de anime
+        // SECCIÓN 2 — Formatos (anime o manga)
         // ═══════════════════════════════════════════════════════════════════
         AnimatedVisibility(
-            visible = selectedFilter == "Anime",
+            visible = selectedFilter == "Anime" || selectedFilter == "Manga",
             enter = fadeIn() + expandVertically(),
             exit = fadeOut() + shrinkVertically()
         ) {
@@ -562,7 +566,8 @@ private fun SearchDiscoveryView(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 16.dp)
                 ) {
-                    items(formatFilters) { format ->
+                    val filters = if (selectedFilter == "Manga") mangaFormatFilters else animeFormatFilters
+                    items(filters) { format ->
                         FormatChip(
                             label = format,
                             isActive = selectedFormat == format,
@@ -580,7 +585,11 @@ private fun SearchDiscoveryView(
 
         SectionHeader(title = "Géneros populares")
 
-        val displayGenres = PopularGenres.popularGenres
+        val displayGenres = if (selectedFilter == "Manga") {
+            PopularGenres.popularMangaGenres
+        } else {
+            PopularGenres.popularGenres
+        }
         val chunked = displayGenres.chunked(2)
 
         Column(
@@ -1494,12 +1503,19 @@ fun AnimeCardItemMinimal(navController: NavController, anime: AnimeCard, isManga
 @Composable
 private fun TypePill(type: String) {
     val (color, displayText) = when (type) {
+        // Formatos de anime
         "TV" -> Color(0xFF6366F1) to "TV"
         "Movie" -> Color(0xFFEC4899) to "Movie"
         "OVA" -> Color(0xFF8B5CF6) to "OVA"
         "ONA" -> Color(0xFF14B8A6) to "ONA"
         "Special" -> Color(0xFFF59E0B) to "Special"
         "Music" -> Color(0xFF06B6D4) to "Music"
+        // Formatos de manga
+        "MANGA" -> Color(0xFF10B981) to "Manga"
+        "NOVEL" -> Color(0xFF8B5CF6) to "Novel"
+        "ONE_SHOT" -> Color(0xFFF59E0B) to "One Shot"
+        "MANHWA" -> Color(0xFF3B82F6) to "Manhwa"
+        "MANHUA" -> Color(0xFFEC4899) to "Manhua"
         else -> MaterialTheme.colorScheme.tertiary to type
     }
     Surface(
@@ -1637,12 +1653,19 @@ private fun EpisodesPill(episodes: String) {
 @Composable
 private fun TypeBadge(type: String) {
     val (color, displayText) = when (type) {
+        // Formatos de anime
         "TV" -> Color(0xFF6366F1) to "TV"
         "Movie" -> Color(0xFFEC4899) to "Movie"
         "OVA" -> Color(0xFF8B5CF6) to "OVA"
         "ONA" -> Color(0xFF14B8A6) to "ONA"
         "Special" -> Color(0xFFF59E0B) to "Special"
         "Music" -> Color(0xFF06B6D4) to "Music"
+        // Formatos de manga
+        "MANGA" -> Color(0xFF10B981) to "Manga"
+        "NOVEL" -> Color(0xFF8B5CF6) to "Novel"
+        "ONE_SHOT" -> Color(0xFFF59E0B) to "One Shot"
+        "MANHWA" -> Color(0xFF3B82F6) to "Manhwa"
+        "MANHUA" -> Color(0xFFEC4899) to "Manhua"
         else -> MaterialTheme.colorScheme.tertiary to type
     }
     Surface(
@@ -2007,6 +2030,7 @@ private fun FiltersBottomSheet(
     selectedQuick: String?,
     selectedFormat: String?,
     selectedGenreId: String?,
+    selectedFilter: String = "Anime",
     onQuickFilterSelected: (String) -> Unit,
     onFormatSelected: (String) -> Unit,
     onGenreSelected: (String) -> Unit,
@@ -2117,7 +2141,8 @@ private fun FiltersBottomSheet(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 20.dp)
                 ) {
-                    items(formatFilters) { format ->
+                    val filters = if (selectedFilter == "Manga") mangaFormatFilters else animeFormatFilters
+                    items(filters) { format ->
                         FormatChip(
                             label = format,
                             isActive = selectedFormat == format,

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchState.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchState.kt
@@ -14,6 +14,7 @@ data class SearchState(
     val selectedGenreId: String? = null,
     val selectedQuickFilter: String? = null,
     val selectedFormat: String? = null,
+    val mediaType: String = "Anime", // Tracks whether we're searching Anime or Manga (persists when filter changes to "Géneros")
 
     // Search results
     val animeList: List<AnimeCard> = emptyList(),
@@ -46,6 +47,6 @@ data class SearchState(
      */
     val canPerformSearch: Boolean
         get() = selectedQuickFilter != null ||
-                (searchQuery.isNotBlank() && selectedFilter == "Anime") ||
+                (searchQuery.isNotBlank() && (selectedFilter == "Anime" || selectedFilter == "Manga")) ||
                 (selectedFilter == "Géneros" && selectedGenreId != null)
 }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchState.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/search/SearchState.kt
@@ -48,5 +48,5 @@ data class SearchState(
     val canPerformSearch: Boolean
         get() = selectedQuickFilter != null ||
                 (searchQuery.isNotBlank() && (selectedFilter == "Anime" || selectedFilter == "Manga")) ||
-                (selectedFilter == "Géneros" && selectedGenreId != null)
+                selectedGenreId != null // Genre search (works with both Anime and Manga)
 }


### PR DESCRIPTION
# Manga Support via AniList

## Summary

This PR introduces full manga support powered by the AniList GraphQL API, including manga search, detail pages, character information, recommendations, and manga-specific filtering.

The update expands Seijaku List beyond anime tracking, providing support for manga, novels, one-shots, manhwa, and manhua.

## Manga Details

### New Manga Detail Screen

Added a dedicated manga detail experience featuring:

- Overview tab
- Characters tab
- Recommendations support
- AniList metadata integration

### Character Support

- Added manga character retrieval through AniList.
- Implemented dedicated character detail handling.
- Integrated manga characters into the detail experience.

### ViewModels

Added:

- `MangaDetailAniListViewModel`
- `MangaCharacterDetailViewModel`

for manga state management and data loading.

## Search Improvements

### Manga Search

Added support for searching:

- Manga
- Novel
- One Shot
- Manhwa
- Manhua

### Search Filters

- Split format filters into Anime and Manga categories.
- Updated search logic to dynamically switch between anime and manga filters.
- Added support for genre-based manga searches.

### Popular Genres

- Added manga-specific popular genres.
- Updated search recommendations based on selected media type.

## GraphQL and Repository Layer

### GraphQL

Added:

- Manga detail queries
- Manga character queries

Extended GraphQL mappings to support manga-specific metadata.

### Repository

Expanded `AnimeAniListRepository` with support for:

- Manga details
- Manga characters
- Manga recommendations
- Manga search

## UI Enhancements

### Manga Format Indicators

Added dedicated badges and pills for:

- Manga
- Novel
- One Shot
- Manhwa
- Manhua

### Search Experience

- Improved media type handling throughout the search flow.
- Added genre filtering for anime and manga searches.
- Removed the standalone Genres category and integrated genres directly into search filters.

## Benefits

- Expands Seijaku List beyond anime tracking.
- Provides a unified Anime and Manga discovery experience.
- Improves search flexibility with media-specific filters.
- Establishes the foundation for future manga collection and tracking features.