### PR TITLE
Feat/manga detail

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -24,7 +24,7 @@
       </SelectionState>
       <SelectionState runConfigName="MainActivity (1)">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-05-10T19:25:59.738607885Z">
+        <DropdownSelection timestamp="2026-07-15T22:15:22.420196162Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=ZY22FRZB73" />

--- a/app/src/main/java/com/yumedev/seijakulist/data/mapper/AniListMangaMapper.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/data/mapper/AniListMangaMapper.kt
@@ -37,7 +37,8 @@ fun GetMangaDetailsQuery.Media.toMangaDetail(): MangaDetail {
         title = fields.title?.romaji ?: fields.title?.english ?: fields.title?.native ?: "Sin título",
         titleEnglish = fields.title?.english ?: "No encontrado",
         titleJapanese = fields.title?.native ?: "No encontrado",
-        images = fields.coverImage?.extraLarge ?: fields.coverImage?.large ?: fields.bannerImage ?: "",
+        images = fields.coverImage?.extraLarge ?: fields.coverImage?.large ?: "",
+        bannerImage = fields.bannerImage,
         typeManga = fields.format?.name ?: "UNKNOWN",
         source = fields.source?.name ?: "UNKNOWN",
         chapters = this.chapters, // chapters está en GetMangaDetailsQuery.Media, no en MediaFields

--- a/app/src/main/java/com/yumedev/seijakulist/domain/models/MangaDetail.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/domain/models/MangaDetail.kt
@@ -14,6 +14,7 @@ data class MangaDetail(
     val titleEnglish: String,
     val titleJapanese: String,
     val images: String,
+    val bannerImage: String?,
     val typeManga: String,  // MANGA, NOVEL, ONE_SHOT, MANHWA, MANHUA
     val source: String,
     val chapters: Int?,     // Número de capítulos (null si es desconocido)

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListBottomSheetComponents.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListBottomSheetComponents.kt
@@ -1,0 +1,593 @@
+package com.yumedev.seijakulist.ui.screens.add_to_list
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.yumedev.seijakulist.domain.models.AnimeDetail
+import com.yumedev.seijakulist.ui.theme.*
+import java.text.SimpleDateFormat
+
+// ============================================================================
+// MODAL HEADER - FIJO
+// ============================================================================
+
+@Composable
+fun ModalHeader(
+    anime: AnimeDetail?,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Poster pequeño
+            if (anime != null) {
+                AsyncImage(
+                    model = anime.images,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(60.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    contentScale = ContentScale.Crop
+                )
+            }
+
+            // Títulos
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                if (anime != null) {
+                    Text(
+                        text = anime.title,
+                        fontFamily = PoppinsBold,
+                        fontSize = 18.sp,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (!anime.titleJapanese.isNullOrBlank()) {
+                        Text(
+                            text = anime.titleJapanese,
+                            fontFamily = PoppinsRegular,
+                            fontSize = 13.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+            }
+
+            // Botón cerrar
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = "Cerrar",
+                    fontFamily = PoppinsMedium,
+                    fontSize = 14.sp
+                )
+            }
+        }
+
+        // Divider
+        HorizontalDivider(
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+        )
+    }
+}
+
+// ============================================================================
+// STATUS SELECTOR - Radio buttons verticales
+// ============================================================================
+
+@Composable
+fun StatusSelector(
+    selectedStatus: String?,
+    onStatusSelected: (String?) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val statusList = listOf(
+        "Viendo" to Icons.Default.PlayArrow,
+        "Completado" to Icons.Default.CheckCircle,
+        "Pendiente" to Icons.Default.WatchLater,
+        "Abandonado" to Icons.Default.Close,
+        "Planeado" to Icons.Default.EventNote
+    )
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "¿Dónde está hoy?",
+            fontFamily = PoppinsRegular,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 4.dp)
+        )
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(0.dp)
+        ) {
+            statusList.forEachIndexed { index, (status, icon) ->
+                StatusRadioItem(
+                    status = status,
+                    icon = icon,
+                    isSelected = selectedStatus == status,
+                    onClick = { onStatusSelected(if (selectedStatus == status) null else status) }
+                )
+
+                // Agregar divider entre elementos (excepto después del último)
+                if (index < statusList.size - 1) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusRadioItem(
+    status: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = status,
+                fontFamily = PoppinsRegular,
+                fontSize = 15.sp,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        RadioButton(
+            selected = isSelected,
+            onClick = onClick,
+            colors = RadioButtonDefaults.colors(
+                selectedColor = MaterialTheme.colorScheme.primary
+            )
+        )
+    }
+}
+
+// ============================================================================
+// PLANNED SECTION
+// ============================================================================
+
+@Composable
+fun PlannedSection(
+    priority: String?,
+    note: String,
+    onPriorityChanged: (String?) -> Unit,
+    onNoteChanged: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Prioridad
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Prioridad",
+                fontFamily = PoppinsRegular,
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                val priorities = listOf("Alta", "Media", "Baja")
+                priorities.forEach { p ->
+                    val isSelected = priority == p
+                    OutlinedButton(
+                        onClick = { onPriorityChanged(if (isSelected) null else p) },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            containerColor = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
+                            else Color.Transparent,
+                            contentColor = if (isSelected) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurface
+                        ),
+                        border = androidx.compose.foundation.BorderStroke(
+                            width = if (isSelected) 2.dp else 1.dp,
+                            color = if (isSelected) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+                        ),
+                        shape = RoundedCornerShape(12.dp)
+                    ) {
+                        Text(
+                            text = p,
+                            fontFamily = if (isSelected) PoppinsBold else PoppinsRegular,
+                            fontSize = 14.sp
+                        )
+                    }
+                }
+            }
+        }
+
+        // Nota de plan
+        OutlinedTextField(
+            value = note,
+            onValueChange = onNoteChanged,
+            placeholder = {
+                Text(
+                    "¿Por qué esperás verla?",
+                    fontFamily = PoppinsRegular,
+                    fontSize = 14.sp
+                )
+            },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+            ),
+            textStyle = androidx.compose.ui.text.TextStyle(
+                fontFamily = PoppinsRegular,
+                fontSize = 14.sp
+            ),
+            maxLines = 3
+        )
+    }
+}
+
+// ============================================================================
+// RATING SECTION - Estrellas
+// ============================================================================
+
+@Composable
+fun RatingSection(
+    rating: Float,
+    onRatingChanged: (Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "Tu calificación",
+            fontFamily = PoppinsRegular,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        // Rating bar con estrellas
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            for (i in 1..5) {
+                val isFilled = rating >= i * 2
+                val isHalf = rating >= (i * 2 - 1) && rating < i * 2
+
+                IconButton(
+                    onClick = {
+                        val newRating = when {
+                            isFilled -> (i * 2 - 1).toFloat()
+                            isHalf -> (i * 2).toFloat()
+                            else -> (i * 2 - 1).toFloat()
+                        }
+                        onRatingChanged(newRating)
+                    },
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        imageVector = when {
+                            isFilled -> Icons.Default.Star
+                            isHalf -> Icons.Default.StarHalf
+                            else -> Icons.Default.StarOutline
+                        },
+                        contentDescription = null,
+                        modifier = Modifier.size(32.dp),
+                        tint = if (isFilled || isHalf) Color(0xFFFFD700)
+                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// OPINION SECTION
+// ============================================================================
+
+@Composable
+fun OpinionSection(
+    opinion: String,
+    onOpinionChanged: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val maxChars = 500
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Una nota para vos (opcional)",
+                fontFamily = PoppinsRegular,
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = "${opinion.length}/$maxChars",
+                fontFamily = PoppinsRegular,
+                fontSize = 12.sp,
+                color = when {
+                    opinion.length >= maxChars -> MaterialTheme.colorScheme.error
+                    opinion.length > maxChars * 0.8 -> Color(0xFFFFCA28)
+                    else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                }
+            )
+        }
+
+        OutlinedTextField(
+            value = opinion,
+            onValueChange = { if (it.length <= maxChars) onOpinionChanged(it) },
+            placeholder = {
+                Text(
+                    "Qué te dejó esta obra...",
+                    fontFamily = PoppinsRegular,
+                    fontSize = 14.sp
+                )
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(100.dp),
+            shape = RoundedCornerShape(12.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+            ),
+            textStyle = androidx.compose.ui.text.TextStyle(
+                fontFamily = PoppinsRegular,
+                fontSize = 14.sp
+            ),
+            maxLines = 4,
+            isError = opinion.length >= maxChars
+        )
+    }
+}
+
+// ============================================================================
+// DATES SECTION
+// ============================================================================
+
+@Composable
+fun DatesSection(
+    startDate: Long?,
+    endDate: Long?,
+    canSelectEndDate: Boolean,
+    onStartDateClick: () -> Unit,
+    onEndDateClick: () -> Unit,
+    dateFormat: SimpleDateFormat,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "Fechas (opcional)",
+            fontFamily = PoppinsRegular,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // Fecha inicio
+            DateCard(
+                label = "Empezó",
+                placeholder = "Elegir fecha",
+                date = startDate,
+                enabled = true,
+                onClick = onStartDateClick,
+                dateFormat = dateFormat,
+                modifier = Modifier.weight(1f)
+            )
+
+            // Fecha final
+            DateCard(
+                label = "Terminó",
+                placeholder = "Elegir fecha",
+                date = endDate,
+                enabled = canSelectEndDate,
+                onClick = onEndDateClick,
+                dateFormat = dateFormat,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun DateCard(
+    label: String,
+    placeholder: String,
+    date: Long?,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    dateFormat: SimpleDateFormat,
+    modifier: Modifier = Modifier
+) {
+    OutlinedCard(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = if (enabled) MaterialTheme.colorScheme.surface
+            else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+        ),
+        border = androidx.compose.foundation.BorderStroke(
+            width = 1.dp,
+            color = if (enabled) MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+            else MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = label,
+                fontFamily = PoppinsRegular,
+                fontSize = 12.sp,
+                color = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant
+                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+            )
+            Text(
+                text = date?.let { dateFormat.format(it) } ?: placeholder,
+                fontFamily = PoppinsMedium,
+                fontSize = 14.sp,
+                color = if (enabled) MaterialTheme.colorScheme.onSurface
+                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+            )
+        }
+    }
+}
+
+// ============================================================================
+// ACTION BUTTON - FIJO EN EL BOTTOM
+// ============================================================================
+
+@Composable
+fun ActionButton(
+    isAdded: Boolean,
+    selectedStatus: String?,
+    onSave: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        // Botones con background sólido
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.background) // Background solo en esta parte
+                .padding(bottom = 16.dp) // Padding adicional para separación
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                // Botón eliminar (solo si está añadido)
+                if (isAdded) {
+                    OutlinedButton(
+                        onClick = onDelete,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(56.dp),
+                        shape = RoundedCornerShape(14.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error
+                        ),
+                        border = androidx.compose.foundation.BorderStroke(
+                            1.5.dp,
+                            MaterialTheme.colorScheme.error
+                        )
+                    ) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            "Eliminar",
+                            fontSize = 15.sp,
+                            fontFamily = PoppinsBold
+                        )
+                    }
+                }
+
+                // Botón guardar/añadir
+                Button(
+                    onClick = onSave,
+                    modifier = Modifier
+                        .weight(if (isAdded) 1f else 1f)
+                        .height(56.dp),
+                    shape = RoundedCornerShape(14.dp),
+                    enabled = selectedStatus != null,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFFD4C5A9), // Color beige/crema del diseño
+                        contentColor = Color(0xFF3E2723), // Texto oscuro para contraste
+                        disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                ) {
+                    Text(
+                        if (isAdded) "Guardar" else "Añadir a mi lista",
+                        fontSize = 15.sp,
+                        fontFamily = PoppinsBold
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListMangaBottomSheetComponents.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListMangaBottomSheetComponents.kt
@@ -524,8 +524,15 @@ fun AddToListMangaModalContent(
                     isRereading,
                     if (selectedStatus == "Planeado") plannedNote else opinion
                 )
+                // Cerrar el modal después de guardar
+                onDismiss()
             },
-            onDelete = onDelete,
+            onDelete = {
+                // Ejecutar callback de eliminación
+                onDelete()
+                // Cerrar el modal después de eliminar
+                onDismiss()
+            },
             modifier = Modifier
                 .background(color = MaterialTheme.colorScheme.background)
                 .padding(horizontal = 20.dp, vertical = 16.dp)

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListMangaBottomSheetComponents.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListMangaBottomSheetComponents.kt
@@ -1,0 +1,535 @@
+package com.yumedev.seijakulist.ui.screens.add_to_list
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.StarHalf
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.yumedev.seijakulist.domain.models.MangaDetail
+import com.yumedev.seijakulist.ui.theme.*
+
+// ============================================================================
+// MODAL HEADER PARA MANGA - FIJO
+// ============================================================================
+
+@Composable
+fun MangaModalHeader(
+    manga: MangaDetail?,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Poster pequeño
+            if (manga != null) {
+                AsyncImage(
+                    model = manga.images,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(60.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    contentScale = ContentScale.Crop
+                )
+            }
+
+            // Títulos
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                if (manga != null) {
+                    Text(
+                        text = manga.title,
+                        fontFamily = PoppinsBold,
+                        fontSize = 18.sp,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (!manga.titleJapanese.isNullOrBlank()) {
+                        Text(
+                            text = manga.titleJapanese,
+                            fontFamily = PoppinsRegular,
+                            fontSize = 13.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+            }
+
+            // Botón cerrar
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = "Cerrar",
+                    fontFamily = PoppinsMedium,
+                    fontSize = 14.sp
+                )
+            }
+        }
+
+        // Divider
+        HorizontalDivider(
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+        )
+    }
+}
+
+// ============================================================================
+// STATUS SELECTOR PARA MANGA - Radio buttons verticales
+// ============================================================================
+
+@Composable
+fun MangaStatusSelector(
+    selectedStatus: String?,
+    onStatusSelected: (String?) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val statusList = listOf(
+        "Leyendo" to Icons.Default.MenuBook,
+        "Completado" to Icons.Default.CheckCircle,
+        "Pendiente" to Icons.Default.WatchLater,
+        "Abandonado" to Icons.Default.Close,
+        "Planeado" to Icons.Default.EventNote
+    )
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "¿Dónde está hoy?",
+            fontFamily = PoppinsRegular,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 4.dp)
+        )
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(0.dp)
+        ) {
+            statusList.forEachIndexed { index, (status, icon) ->
+                MangaStatusRadioItem(
+                    status = status,
+                    icon = icon,
+                    isSelected = selectedStatus == status,
+                    onClick = { onStatusSelected(if (selectedStatus == status) null else status) }
+                )
+
+                // Agregar divider entre elementos (excepto después del último)
+                if (index < statusList.size - 1) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MangaStatusRadioItem(
+    status: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = status,
+                fontFamily = PoppinsRegular,
+                fontSize = 15.sp,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        RadioButton(
+            selected = isSelected,
+            onClick = onClick,
+            colors = RadioButtonDefaults.colors(
+                selectedColor = MaterialTheme.colorScheme.primary
+            )
+        )
+    }
+}
+
+// ============================================================================
+// PROGRESS SECTION - Capítulos y Volúmenes
+// ============================================================================
+
+@Composable
+fun ProgressSection(
+    currentChapter: Int,
+    totalChapters: Int?,
+    currentVolume: Int,
+    totalVolumes: Int?,
+    onChapterChanged: (Int) -> Unit,
+    onVolumeChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            text = "Progreso",
+            fontFamily = PoppinsRegular,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // Capítulo
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = "Capítulo",
+                    fontFamily = PoppinsRegular,
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    OutlinedTextField(
+                        value = currentChapter.toString(),
+                        onValueChange = {
+                            val newValue = it.toIntOrNull() ?: 0
+                            onChapterChanged(newValue.coerceAtLeast(0))
+                        },
+                        modifier = Modifier.weight(1f),
+                        textStyle = androidx.compose.ui.text.TextStyle(
+                            fontFamily = PoppinsMedium,
+                            fontSize = 16.sp
+                        ),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        singleLine = true,
+                        shape = RoundedCornerShape(12.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+                        )
+                    )
+                    Text(
+                        text = "/ ${totalChapters ?: "?"}",
+                        fontFamily = PoppinsMedium,
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+
+            // Volumen
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = "Volumen",
+                    fontFamily = PoppinsRegular,
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    OutlinedTextField(
+                        value = currentVolume.toString(),
+                        onValueChange = {
+                            val newValue = it.toIntOrNull() ?: 0
+                            onVolumeChanged(newValue.coerceAtLeast(0))
+                        },
+                        modifier = Modifier.weight(1f),
+                        textStyle = androidx.compose.ui.text.TextStyle(
+                            fontFamily = PoppinsMedium,
+                            fontSize = 16.sp
+                        ),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        singleLine = true,
+                        shape = RoundedCornerShape(12.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+                        )
+                    )
+                    Text(
+                        text = "/ ${totalVolumes ?: "?"}",
+                        fontFamily = PoppinsMedium,
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// REREADING TOGGLE - Switch
+// ============================================================================
+
+@Composable
+fun RereadingToggle(
+    isRereading: Boolean,
+    onRereadingChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onRereadingChanged(!isRereading) }
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "Estoy releyéndolo",
+            fontFamily = PoppinsRegular,
+            fontSize = 15.sp,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Switch(
+            checked = isRereading,
+            onCheckedChange = onRereadingChanged,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = MaterialTheme.colorScheme.primary,
+                checkedTrackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+            )
+        )
+    }
+}
+
+// ============================================================================
+// RATING SECTION PARA MANGA - 5 Estrellas (igual que anime)
+// ============================================================================
+
+@Composable
+fun MangaRatingSection(
+    rating: Float,
+    onRatingChanged: (Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "Tu calificación",
+            fontFamily = PoppinsRegular,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        // Rating bar con 5 estrellas (igual que anime)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            for (i in 1..5) {
+                val isFilled = rating >= i * 2
+                val isHalf = rating >= (i * 2 - 1) && rating < i * 2
+
+                IconButton(
+                    onClick = {
+                        val newRating = when {
+                            isFilled -> (i * 2 - 1).toFloat()
+                            isHalf -> (i * 2).toFloat()
+                            else -> (i * 2 - 1).toFloat()
+                        }
+                        onRatingChanged(newRating)
+                    },
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        imageVector = when {
+                            isFilled -> Icons.Default.Star
+                            isHalf -> Icons.AutoMirrored.Filled.StarHalf
+                            else -> Icons.Default.StarOutline
+                        },
+                        contentDescription = null,
+                        modifier = Modifier.size(32.dp),
+                        tint = if (isFilled || isHalf) Color(0xFFFFD700)
+                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// MAIN MODAL CONTENT - Integra todos los componentes
+// ============================================================================
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddToListMangaModalContent(
+    modifier: Modifier = Modifier,
+    manga: MangaDetail?,
+    existingManga: Any?, // TODO: Cambiar a MangaEntityDomain cuando esté implementado
+    isAdded: Boolean,
+    onDismiss: () -> Unit,
+    onSave: (String?, Float, Int, Int, Boolean, String) -> Unit,
+    onDelete: () -> Unit
+) {
+    // Estado del formulario
+    // TODO: Cuando MangaEntityDomain esté implementado, obtener valores de existingManga
+    var selectedStatus by remember { mutableStateOf<String?>(null) }
+    var rating by remember { mutableStateOf(0f) }
+    var currentChapter by remember { mutableIntStateOf(0) }
+    var currentVolume by remember { mutableIntStateOf(0) }
+    var isRereading by remember { mutableStateOf(false) }
+    var opinion by remember { mutableStateOf("") }
+    var plannedPriority by remember { mutableStateOf<String?>(null) }
+    var plannedNote by remember { mutableStateOf("") }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // HEADER FIJO
+            MangaModalHeader(
+                manga = manga,
+                onDismiss = onDismiss
+            )
+
+            // CONTENIDO SCROLLEABLE
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(androidx.compose.foundation.rememberScrollState())
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 160.dp), // Espacio para el botón + navigation bar
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Selector de Estado
+                MangaStatusSelector(
+                    selectedStatus = selectedStatus,
+                    onStatusSelected = { selectedStatus = it }
+                )
+
+                // Contenido condicional según estado
+                when (selectedStatus) {
+                    "Planeado" -> {
+                        PlannedSection(
+                            priority = plannedPriority,
+                            note = plannedNote,
+                            onPriorityChanged = { plannedPriority = it },
+                            onNoteChanged = { plannedNote = it }
+                        )
+                    }
+                    null -> {
+                        // Estado vacío, no mostrar nada
+                    }
+                    else -> {
+                        // Leyendo, Completado, Pendiente, Abandonado
+
+                        // Progreso
+                        ProgressSection(
+                            currentChapter = currentChapter,
+                            totalChapters = manga?.chapters,
+                            currentVolume = currentVolume,
+                            totalVolumes = manga?.volumes,
+                            onChapterChanged = { currentChapter = it },
+                            onVolumeChanged = { currentVolume = it }
+                        )
+
+                        // Estoy releyéndolo
+                        RereadingToggle(
+                            isRereading = isRereading,
+                            onRereadingChanged = { isRereading = it }
+                        )
+
+                        // Calificación
+                        MangaRatingSection(
+                            rating = rating,
+                            onRatingChanged = { rating = it }
+                        )
+
+                        // Opinión
+                        OpinionSection(
+                            opinion = opinion,
+                            onOpinionChanged = { opinion = it }
+                        )
+                    }
+                }
+            }
+        }
+
+        // BOTÓN FIJO EN EL BOTTOM
+        ActionButton(
+            isAdded = isAdded,
+            selectedStatus = selectedStatus,
+            onSave = {
+                // TODO: Implementar lógica de guardado después
+                // Por ahora solo llamar al callback con valores dummy
+                val scoreToPass = if (selectedStatus == "Planeado") 0f else rating
+                onSave(
+                    selectedStatus,
+                    scoreToPass,
+                    currentChapter,
+                    currentVolume,
+                    isRereading,
+                    if (selectedStatus == "Planeado") plannedNote else opinion
+                )
+            },
+            onDelete = onDelete,
+            modifier = Modifier
+                .background(color = MaterialTheme.colorScheme.background)
+                .padding(horizontal = 20.dp, vertical = 16.dp)
+                .align(Alignment.BottomCenter)
+        )
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListScreen.kt
@@ -41,7 +41,7 @@ fun AddToListScreen(
     val animeDetail by viewModel.animeDetail.collectAsState()
     val existingAnime by viewModel.existingAnime.collectAsState()
     val scope = rememberCoroutineScope()
-    val snackbarHostState = remember { SnackbarHostState() }
+    val context = androidx.compose.ui.platform.LocalContext.current
     val sheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true // Mantiene el modal fijo en su altura inicial
     )
@@ -90,32 +90,28 @@ fun AddToListScreen(
                         plannedNote = note
                     )
 
-                    val statusEmoji = when (status) {
-                        "Viendo" -> "▶️"
-                        "Completado" -> "✅"
-                        "Pendiente" -> "⏳"
-                        "Abandonado" -> "❌"
-                        "Planeado" -> "📋"
-                        else -> "📺"
-                    }
                     val message = if (isAdded)
-                        "$statusEmoji Anime actualizado en tu lista como '$status'"
+                        "Anime actualizado en tu lista como '$status'"
                     else
-                        "$statusEmoji Anime añadido a tu lista como '$status'"
+                        "Anime añadido a tu lista como '$status'"
 
-                    snackbarHostState.showSnackbar(
-                        message = message,
-                        duration = SnackbarDuration.Short
-                    )
-
-                    navController.navigateUp()
+                    android.widget.Toast.makeText(
+                        context,
+                        message,
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                    // El dismiss/navigateUp se maneja en el componente modal
                 }
             },
             onDelete = {
                 scope.launch {
                     // TODO: Implement delete method
-                    snackbarHostState.showSnackbar("Anime eliminado de tu lista")
-                    navController.navigateUp()
+                    android.widget.Toast.makeText(
+                        context,
+                        "Anime eliminado de tu lista",
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                    // El dismiss/navigateUp se maneja en el componente modal
                 }
             }
         )
@@ -273,8 +269,15 @@ fun AddToListModalContent(
                     priorityToPass,
                     noteToPass
                 )
+                // Cerrar el modal después de guardar
+                onDismiss()
             },
-            onDelete = onDelete,
+            onDelete = {
+                // Ejecutar callback de eliminación
+                onDelete()
+                // Cerrar el modal después de eliminar
+                onDismiss()
+            },
             modifier = Modifier
                 .background(color = MaterialTheme.colorScheme.background)
                 .padding(horizontal = 20.dp, vertical = 16.dp)

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/add_to_list/AddToListScreen.kt
@@ -29,6 +29,7 @@ import com.yumedev.seijakulist.ui.theme.*
 import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlinx.coroutines.launch
+import androidx.compose.ui.draw.clip
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,6 +42,9 @@ fun AddToListScreen(
     val existingAnime by viewModel.existingAnime.collectAsState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true // Mantiene el modal fijo en su altura inicial
+    )
 
     // Load anime detail if not loaded
     LaunchedEffect(animeId) {
@@ -52,32 +56,28 @@ fun AddToListScreen(
     val isAdded = existingAnime != null
     val anime = animeDetail
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = if (isAdded) "Editar en Mi Lista" else "Añadir a Mi Lista",
-                        fontFamily = PoppinsBold
+    ModalBottomSheet(
+        onDismissRequest = { navController.navigateUp() },
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.background,
+        dragHandle = {
+            Box(
+                modifier = Modifier
+                    .padding(vertical = 8.dp)
+                    .width(32.dp)
+                    .height(4.dp)
+                    .background(
+                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                        RoundedCornerShape(2.dp)
                     )
-                },
-                navigationIcon = {
-                    IconButton(onClick = { navController.navigateUp() }) {
-                        Icon(Icons.Default.Close, contentDescription = "Cerrar")
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background
-                )
             )
-        },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
-    ) { paddingValues ->
-        AddToListContent(
-            modifier = Modifier.padding(paddingValues),
+        }
+    ) {
+        AddToListModalContent(
             anime = anime,
             existingAnime = existingAnime,
             isAdded = isAdded,
+            onDismiss = { navController.navigateUp() },
             onSave = { status, rating, startDate, endDate, priority, note ->
                 scope.launch {
                     viewModel.addAnimeToList(
@@ -124,7 +124,167 @@ fun AddToListScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AddToListContent(
+fun AddToListModalContent(
+    modifier: Modifier = Modifier,
+    anime: AnimeDetail?,
+    existingAnime: com.yumedev.seijakulist.domain.models.AnimeEntityDomain?,
+    isAdded: Boolean,
+    onDismiss: () -> Unit,
+    onSave: (String?, Float, Long?, Long?, String?, String) -> Unit,
+    onDelete: () -> Unit
+) {
+    // Estado del formulario
+    var selectedStatus by remember { mutableStateOf(existingAnime?.userStatus) }
+    var rating by remember { mutableStateOf(existingAnime?.userScore ?: 0f) }
+    var opinion by remember { mutableStateOf(existingAnime?.userOpiniun ?: "") }
+    var startDate by remember { mutableStateOf(existingAnime?.startDate) }
+    var endDate by remember { mutableStateOf(existingAnime?.endDate) }
+    var plannedPriority by remember { mutableStateOf(existingAnime?.plannedPriority) }
+    var plannedNote by remember { mutableStateOf(existingAnime?.plannedNote ?: "") }
+
+    var showStartPicker by remember { mutableStateOf(false) }
+    var showEndPicker by remember { mutableStateOf(false) }
+
+    val dateFormat = remember { SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()) }
+
+    // DatePicker Dialogs
+    if (showStartPicker) {
+        DatePickerDialog(
+            onDismissRequest = { showStartPicker = false },
+            confirmButton = {
+                TextButton(onClick = { showStartPicker = false }) {
+                    Text("OK", fontFamily = PoppinsMedium)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showStartPicker = false }) {
+                    Text("Cancelar", fontFamily = PoppinsRegular)
+                }
+            }
+        ) {
+            val pickerState = rememberDatePickerState(initialSelectedDateMillis = startDate)
+            DatePicker(state = pickerState)
+            startDate = pickerState.selectedDateMillis
+        }
+    }
+
+    if (showEndPicker) {
+        DatePickerDialog(
+            onDismissRequest = { showEndPicker = false },
+            confirmButton = {
+                TextButton(onClick = { showEndPicker = false }) {
+                    Text("OK", fontFamily = PoppinsMedium)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEndPicker = false }) {
+                    Text("Cancelar", fontFamily = PoppinsRegular)
+                }
+            }
+        ) {
+            val pickerState = rememberDatePickerState(initialSelectedDateMillis = endDate)
+            DatePicker(state = pickerState)
+            endDate = pickerState.selectedDateMillis
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // HEADER FIJO
+            ModalHeader(
+                anime = anime,
+                onDismiss = onDismiss
+            )
+
+            // CONTENIDO SCROLLEABLE
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 160.dp), // Espacio para el botón + navigation bar (aumentado)
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Selector de Estado
+                StatusSelector(
+                    selectedStatus = selectedStatus,
+                    onStatusSelected = { selectedStatus = it }
+                )
+
+                // Contenido condicional según estado
+                when (selectedStatus) {
+                    "Planeado" -> {
+                        PlannedSection(
+                            priority = plannedPriority,
+                            note = plannedNote,
+                            onPriorityChanged = { plannedPriority = it },
+                            onNoteChanged = { plannedNote = it }
+                        )
+                    }
+                    null -> {
+                        // Estado vacío, no mostrar nada
+                    }
+                    else -> {
+                        // Viendo, Completado, Pendiente, Abandonado
+                        RatingSection(
+                            rating = rating,
+                            onRatingChanged = { rating = it }
+                        )
+
+                        OpinionSection(
+                            opinion = opinion,
+                            onOpinionChanged = { opinion = it }
+                        )
+
+                        DatesSection(
+                            startDate = startDate,
+                            endDate = endDate,
+                            canSelectEndDate = selectedStatus == "Completado",
+                            onStartDateClick = { showStartPicker = true },
+                            onEndDateClick = { if (selectedStatus == "Completado") showEndPicker = true },
+                            dateFormat = dateFormat
+                        )
+                    }
+                }
+            }
+        }
+
+        // BOTÓN FIJO EN EL BOTTOM
+        ActionButton(
+            isAdded = isAdded,
+            selectedStatus = selectedStatus,
+            onSave = {
+                val scoreToPass = if (selectedStatus == "Planeado") 0f else rating
+                val priorityToPass = if (selectedStatus == "Planeado") plannedPriority else null
+                val noteToPass = if (selectedStatus == "Planeado" && plannedNote.isNotBlank())
+                    plannedNote
+                else if (opinion.isNotBlank())
+                    opinion
+                else
+                    ""
+
+                onSave(
+                    selectedStatus,
+                    scoreToPass,
+                    startDate,
+                    endDate,
+                    priorityToPass,
+                    noteToPass
+                )
+            },
+            onDelete = onDelete,
+            modifier = Modifier
+                .background(color = MaterialTheme.colorScheme.background)
+                .padding(horizontal = 20.dp, vertical = 16.dp)
+                .align(Alignment.BottomCenter)
+        )
+    }
+}
+
+@Composable
+private fun OldAddToListContent(
     modifier: Modifier = Modifier,
     anime: AnimeDetail?,
     existingAnime: com.yumedev.seijakulist.domain.models.AnimeEntityDomain?,

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/AnimeDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/AnimeDetailScreen.kt
@@ -29,10 +29,13 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.*
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.runtime.*
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -118,16 +121,17 @@ fun AnimeDetailScreen(
     val context = LocalContext.current
     val view = androidx.compose.ui.platform.LocalView.current
 
+    // Modal Bottom Sheet state
+    var showAddToListSheet by remember { mutableStateOf(openSheet) }
+
     // Configurar status bar y navigation bar para esta pantalla
     DisposableEffect(Unit) {
         val window = (context as? android.app.Activity)?.window
         val originalStatusBarColor = window?.statusBarColor
-        val originalNavigationBarColor = window?.navigationBarColor
 
         window?.let {
             WindowCompat.setDecorFitsSystemWindows(it, false)
             it.statusBarColor = android.graphics.Color.TRANSPARENT
-            it.navigationBarColor = android.graphics.Color.TRANSPARENT
         }
 
         onDispose {
@@ -136,9 +140,6 @@ fun AnimeDetailScreen(
                 WindowCompat.setDecorFitsSystemWindows(it, true)
                 originalStatusBarColor?.let { color ->
                     it.statusBarColor = color
-                }
-                originalNavigationBarColor?.let { color ->
-                    it.navigationBarColor = color
                 }
             }
         }
@@ -150,10 +151,8 @@ fun AnimeDetailScreen(
     }
 
     // Handle open sheet parameter
-    LaunchedEffect(openSheet, isLoading, animeDetail) {
-        if (openSheet && !isLoading && animeDetail != null) {
-            navController.navigate("${AppDestinations.ADD_TO_LIST_ROUTE}/${animeDetail!!.malId}")
-        }
+    LaunchedEffect(openSheet) {
+        showAddToListSheet = openSheet
     }
 
     // Set initial tab if provided
@@ -199,9 +198,7 @@ fun AnimeDetailScreen(
                             // Estado B: FAB circular "Editar" (56dp)
                             FloatingActionButton(
                                 onClick = {
-                                    animeDetail?.let {
-                                        navController.navigate("${AppDestinations.ADD_TO_LIST_ROUTE}/${it.malId}")
-                                    }
+                                    showAddToListSheet = true
                                 },
                                 containerColor = MaterialTheme.colorScheme.primary,
                                 contentColor = MaterialTheme.colorScheme.onPrimary,
@@ -225,9 +222,7 @@ fun AnimeDetailScreen(
                             // Estado A: FAB extendido "Añadir a mi lista"
                             ExtendedFloatingActionButton(
                                 onClick = {
-                                    animeDetail?.let {
-                                        navController.navigate("${AppDestinations.ADD_TO_LIST_ROUTE}/${it.malId}")
-                                    }
+                                    showAddToListSheet = true
                                 },
                                 icon = {
                                     Icon(
@@ -335,9 +330,7 @@ fun AnimeDetailScreen(
                                         animeDetail = animeDetail,
                                         isAdded = isAdded,
                                         onAddToListClick = {
-                                            animeDetail?.let {
-                                                navController.navigate("${AppDestinations.ADD_TO_LIST_ROUTE}/${it.malId}")
-                                            }
+                                            showAddToListSheet = true
                                         },
                                         sharedTransitionScope = sharedTransitionScope,
                                         animatedVisibilityScope = animatedVisibilityScope,
@@ -443,6 +436,112 @@ fun AnimeDetailScreen(
                                 )
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    // Modal Bottom Sheet para añadir/editar anime en la lista (Dialog personalizado sin drag)
+    if (showAddToListSheet && animeDetail != null) {
+        Dialog(
+            onDismissRequest = { showAddToListSheet = false },
+            properties = DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true,
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = false // No respetar system bars
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.5f))
+                    .clickable(
+                        onClick = { showAddToListSheet = false },
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ),
+                contentAlignment = Alignment.BottomCenter
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight(0.85f) // 85% de altura
+                        .clickable(
+                            onClick = { }, // No hacer nada al hacer clic en el contenido
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() }
+                        ),
+                    shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    Column {
+                        // Drag handle visual (no funcional)
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .width(32.dp)
+                                    .height(4.dp)
+                                    .background(
+                                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                        RoundedCornerShape(2.dp)
+                                    )
+                            )
+                        }
+
+                        // Contenido del modal
+                        com.yumedev.seijakulist.ui.screens.add_to_list.AddToListModalContent(
+                            anime = animeDetail,
+                            existingAnime = existingAnime,
+                            isAdded = isAdded,
+                            onDismiss = { showAddToListSheet = false },
+                            onSave = { status, rating, startDate, endDate, priority, note ->
+                                scope.launch {
+                                    animeDetailViewModel.addAnimeToList(
+                                        userScore = rating,
+                                        userStatus = status ?: "Viendo",
+                                        userOpinion = note,
+                                        startDate = startDate,
+                                        endDate = endDate,
+                                        plannedPriority = priority,
+                                        plannedNote = note
+                                    )
+
+                                    val statusEmoji = when (status) {
+                                        "Viendo" -> "▶️"
+                                        "Completado" -> "✅"
+                                        "Pendiente" -> "⏳"
+                                        "Abandonado" -> "❌"
+                                        "Planeado" -> "📋"
+                                        else -> "📺"
+                                    }
+                                    val message = if (isAdded)
+                                        "$statusEmoji Anime actualizado en tu lista como '$status'"
+                                    else
+                                        "$statusEmoji Anime añadido a tu lista como '$status'"
+
+                                    snackbarHostState.showSnackbar(
+                                        message = message,
+                                        duration = SnackbarDuration.Short
+                                    )
+
+                                    showAddToListSheet = false
+                                }
+                            },
+                            onDelete = {
+                                scope.launch {
+                                    // TODO: Implement delete method
+                                    snackbarHostState.showSnackbar("Anime eliminado de tu lista")
+                                    showAddToListSheet = false
+                                }
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/AnimeDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/AnimeDetailScreen.kt
@@ -1208,18 +1208,12 @@ private fun AnimeOverviewTab(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     animeDetail.genres.filterNotNull().forEach { genre ->
-                        Surface(
-                            shape = RoundedCornerShape(20.dp),
-                            color = MaterialTheme.colorScheme.surfaceContainerHighest
-                        ) {
-                            Text(
-                                text = genre.name ?: "",
-                                fontFamily = PoppinsMedium,
-                                fontSize = 13.sp,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                modifier = Modifier.padding(horizontal = 14.dp, vertical = 6.dp)
-                            )
-                        }
+                        CompactGenreCard(
+                            genreName = genre.name ?: "",
+                            modifier = Modifier
+                                .width(110.dp)
+                                .height(40.dp)
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/AnimeDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/AnimeDetailScreen.kt
@@ -513,32 +513,26 @@ fun AnimeDetailScreen(
                                         plannedNote = note
                                     )
 
-                                    val statusEmoji = when (status) {
-                                        "Viendo" -> "▶️"
-                                        "Completado" -> "✅"
-                                        "Pendiente" -> "⏳"
-                                        "Abandonado" -> "❌"
-                                        "Planeado" -> "📋"
-                                        else -> "📺"
-                                    }
                                     val message = if (isAdded)
-                                        "$statusEmoji Anime actualizado en tu lista como '$status'"
+                                        "Anime actualizado en tu lista como '$status'"
                                     else
-                                        "$statusEmoji Anime añadido a tu lista como '$status'"
+                                        "Anime añadido a tu lista como '$status'"
 
-                                    snackbarHostState.showSnackbar(
-                                        message = message,
-                                        duration = SnackbarDuration.Short
-                                    )
-
-                                    showAddToListSheet = false
+                                    android.widget.Toast.makeText(
+                                        context,
+                                        message,
+                                        android.widget.Toast.LENGTH_SHORT
+                                    ).show()
                                 }
                             },
                             onDelete = {
                                 scope.launch {
                                     // TODO: Implement delete method
-                                    snackbarHostState.showSnackbar("Anime eliminado de tu lista")
-                                    showAddToListSheet = false
+                                    android.widget.Toast.makeText(
+                                        context,
+                                        "Anime eliminado de tu lista",
+                                        android.widget.Toast.LENGTH_SHORT
+                                    ).show()
                                 }
                             }
                         )

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
@@ -913,51 +913,56 @@ private fun MangaOverviewTab(
 
         // Genres
         if (!mangaDetail?.genres.isNullOrEmpty()) {
-            Card(
+            Column(
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(12.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                ),
-                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Column(
+                Text(
+                    text = "Géneros",
+                    fontFamily = PoppinsBold,
+                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                FlowRow(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    Text(
-                        text = "Géneros",
-                        fontFamily = PoppinsBold,
-                        fontSize = 21.sp,
-                        fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
-                        letterSpacing = 0.3.sp,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)
-                    )
-
-                    LazyRow(
-                        modifier = Modifier.height(55.dp),
-                        contentPadding = PaddingValues(horizontal = 16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(10.dp)
-                    ) {
-                        items(mangaDetail.genres.filterNotNull()) { genre ->
-                            CompactGenreCard(genreName = genre.name ?: "")
-                        }
+                    mangaDetail.genres.filterNotNull().forEach { genre ->
+                        CompactGenreCard(
+                            genreName = genre.name ?: "",
+                            modifier = Modifier
+                                .width(110.dp)
+                                .height(40.dp)
+                        )
                     }
-
-                    Spacer(modifier = Modifier.height(4.dp))
                 }
             }
         }
 
         // Authors
         if (!mangaDetail?.authors.isNullOrEmpty()) {
-            MangaInfoCard(title = "Autores") {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    mangaDetail.authors.forEach { author ->
-                        MangaAuthorRow(
-                            name = author.name,
-                            role = author.role
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Autores",
+                    fontFamily = PoppinsBold,
+                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                mangaDetail.authors.forEachIndexed { index, author ->
+                    MangaSimpleInfoRow(
+                        label = author.role,
+                        value = author.name
+                    )
+                    if (index < mangaDetail.authors.size - 1) {
+                        HorizontalDivider(
+                            modifier = Modifier.padding(vertical = 12.dp),
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
                         )
                     }
                 }
@@ -1192,9 +1197,9 @@ private fun MangaGenreChip(genre: String) {
 }
 
 @Composable
-private fun MangaAuthorRow(
-    name: String,
-    role: String,
+private fun MangaSimpleInfoRow(
+    label: String,
+    value: String,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -1202,30 +1207,20 @@ private fun MangaAuthorRow(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = name,
-                fontFamily = PoppinsBold,
-                fontSize = 14.sp,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Text(
-                text = role,
-                fontFamily = PoppinsRegular,
-                fontSize = 11.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-
-        Icon(
-            imageVector = when {
-                role.contains("Art", ignoreCase = true) -> Icons.Default.Brush
-                role.contains("Story", ignoreCase = true) -> Icons.Default.Create
-                else -> Icons.Default.Person
-            },
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
-            modifier = Modifier.size(20.dp)
+        Text(
+            text = label,
+            fontFamily = PoppinsRegular,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            fontFamily = PoppinsBold,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.End,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -38,6 +40,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -1011,51 +1014,239 @@ private fun MangaCharactersTab(
     navController: NavController,
     modifier: Modifier = Modifier
 ) {
+    var showAll by remember { mutableStateOf(false) }
+    var isSearching by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
+    val focusRequester = remember { FocusRequester() }
+
+    // Auto-focus cuando se activa la búsqueda
+    LaunchedEffect(isSearching) {
+        if (isSearching) {
+            focusRequester.requestFocus()
+        }
+    }
+
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        modifier = modifier.fillMaxWidth()
     ) {
-        when {
-            isLoading -> {
-                Box(
+        // Barra de búsqueda
+        AnimatedVisibility(
+            visible = !isLoading && characters.isNotEmpty(),
+            enter = fadeIn() + expandVertically(),
+            exit = fadeOut() + shrinkVertically()
+        ) {
+            if (isSearching) {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(200.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator(
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-            }
-            characters.isEmpty() -> {
-                MangaEmptyState(message = "No hay personajes disponibles")
-            }
-            else -> {
-                LazyVerticalGrid(
-                    columns = GridCells.Fixed(3),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    modifier = Modifier.heightIn(max = 2000.dp),
-                    userScrollEnabled = false
-                ) {
-                    items(characters, key = { it.idCharacter ?: 0 }) { character ->
-                        MangaCharacterCard(
-                            character = character,
-                            onClick = {
-                                character.idCharacter?.let {
-                                    navController.navigate("character_detail_route/$it")
-                                }
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .focusRequester(focusRequester),
+                    placeholder = {
+                        Text(
+                            text = "Buscar personaje...",
+                            fontFamily = PoppinsRegular,
+                            fontSize = 14.sp
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = "Buscar",
+                            modifier = Modifier.size(20.dp)
+                        )
+                    },
+                    trailingIcon = {
+                        IconButton(onClick = {
+                            if (searchQuery.isEmpty()) {
+                                isSearching = false
+                            } else {
+                                searchQuery = ""
                             }
+                        }) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "Cerrar",
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                    },
+                    singleLine = true,
+                    shape = RoundedCornerShape(50),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant
+                    ),
+                    textStyle = TextStyle(
+                        fontFamily = PoppinsMedium,
+                        fontSize = 14.sp
+                    )
+                )
+            } else {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "Reparto principal",
+                        fontFamily = PoppinsBold,
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    IconButton(onClick = { isSearching = true }) {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = "Buscar",
+                            tint = MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }
             }
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            when {
+                isLoading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                characters.isEmpty() -> {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.People,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                            modifier = Modifier.size(64.dp)
+                        )
+                        Text(
+                            text = "Sin información de reparto",
+                            fontFamily = PoppinsBold,
+                            fontSize = 18.sp,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            text = "Este manga aún no tiene personajes registrados",
+                            fontFamily = PoppinsRegular,
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                    }
+                }
+
+                else -> {
+                    // Filtrar personajes según búsqueda
+                    val filteredCharacters = if (searchQuery.isBlank()) {
+                        characters
+                    } else {
+                        characters.filter { character ->
+                            character.nameCharacter?.contains(searchQuery, ignoreCase = true) == true
+                        }
+                    }
+
+                    // Mostrar mensaje si no hay resultados
+                    if (filteredCharacters.isEmpty()) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 32.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Search,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                    modifier = Modifier.size(48.dp)
+                                )
+                                Text(
+                                    text = "No se encontraron personajes",
+                                    fontFamily = PoppinsBold,
+                                    fontSize = 16.sp,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = "Intenta con otro nombre",
+                                    fontFamily = PoppinsRegular,
+                                    fontSize = 14.sp,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    } else {
+                        // Mostrar 9 personajes o todos según el estado
+                        val displayedCharacters = if (showAll || searchQuery.isNotBlank()) {
+                            filteredCharacters
+                        } else {
+                            filteredCharacters.take(9)
+                        }
+
+                        Column(
+                            modifier = Modifier.imePadding(),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            displayedCharacters.forEach { character ->
+                                MangaCharacterListItem(
+                                    character = character,
+                                    onClick = {
+                                        character.idCharacter?.let { id ->
+                                            navController.navigate("character_detail_route/$id")
+                                        }
+                                    }
+                                )
+                                if (character != displayedCharacters.last()) {
+                                    HorizontalDivider(
+                                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                                    )
+                                }
+                            }
+
+                            // Botón "Ver todo el reparto" / "Ver menos" si hay más de 9 personajes y no está buscando
+                            if (filteredCharacters.size > 9 && searchQuery.isBlank()) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                OutlinedButton(
+                                    onClick = { showAll = !showAll },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    shape = RoundedCornerShape(12.dp)
+                                ) {
+                                    Text(
+                                        text = if (showAll) "Ver menos" else "Ver todo el reparto",
+                                        fontFamily = PoppinsMedium,
+                                        fontSize = 14.sp
+                                    )
+                                }
+                            }
+
+                            // Spacer adicional para que el contenido no quede tapado por el teclado
+                            Spacer(modifier = Modifier.height(200.dp))
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -1226,106 +1417,125 @@ private fun MangaSimpleInfoRow(
 }
 
 @Composable
-private fun MangaCharacterCard(
+private fun MangaCharacterListItem(
     character: AnimeCharactersDetail,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // Colores según el rol
-    val roleColor = when (character.role.lowercase()) {
-        "main" -> Color(0xFFFF5722) // Naranja rojizo - protagonista
-        "supporting" -> Color(0xFF2196F3) // Azul - soporte
-        else -> Color(0xFF9E9E9E) // Gris - otro
+    val context = LocalContext.current
+    val characterName = character.nameCharacter ?: "Desconocido"
+    val characterRole = when (character.role) {
+        "Main" -> "Protagonista"
+        "Supporting" -> "Principal"
+        else -> character.role
     }
+    val characterImage = character.imageCharacter?.jpg?.imageUrl
 
-    Card(
-        onClick = onClick,
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(10.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Column {
-            // Character image - muy compacto para 3 columnas
+        // Avatar e información del personaje (izquierda)
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.weight(1f)
+        ) {
+            // Avatar circular con imagen o inicial
             Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(0.62f) // Reducido más para 3 columnas
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                contentAlignment = Alignment.Center
             ) {
-                AsyncImage(
-                    model = character.imageCharacter?.jpg?.imageUrl,
-                    contentDescription = character.nameCharacter,
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
-                )
-
-                // Gradiente en la parte inferior para mejor legibilidad del nombre
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(50.dp)
-                        .align(Alignment.BottomCenter)
-                        .background(
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    Color.Transparent,
-                                    Color.Black.copy(alpha = 0.75f)
-                                )
-                            )
-                        )
-                )
-
-                // Role badge mejorado - icono + texto compacto
-                if (character.role.isNotBlank()) {
-                    val (icon, roleText) = when (character.role.lowercase()) {
-                        "main" -> "★" to "Main"
-                        "supporting" -> "◆" to "Supp"
-                        else -> "•" to character.role.take(4)
-                    }
-
-                    Surface(
+                if (!characterImage.isNullOrBlank()) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(context)
+                            .data(characterImage)
+                            .size(Size.ORIGINAL)
+                            .crossfade(true)
+                            .build(),
+                        contentDescription = characterName,
                         modifier = Modifier
-                            .align(Alignment.TopStart)
-                            .padding(4.dp),
-                        shape = RoundedCornerShape(4.dp),
-                        color = roleColor.copy(alpha = 0.9f)
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
-                            horizontalArrangement = Arrangement.spacedBy(2.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = icon,
-                                fontFamily = PoppinsBold,
-                                fontSize = 9.sp,
-                                color = Color.White
-                            )
-                            Text(
-                                text = roleText,
-                                fontFamily = PoppinsBold,
-                                fontSize = 9.sp,
-                                color = Color.White,
-                                letterSpacing = 0.2.sp
-                            )
-                        }
-                    }
+                            .fillMaxSize()
+                            .clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    Text(
+                        text = characterName.first().uppercase(),
+                        fontFamily = PoppinsBold,
+                        fontSize = 18.sp,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
                 }
+            }
 
-                // Character name sobre la imagen - en la parte inferior
+            // Nombre y rol
+            Column(
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
                 Text(
-                    text = character.nameCharacter ?: "Unknown",
+                    text = characterName,
                     fontFamily = PoppinsBold,
-                    fontSize = 9.sp,
-                    color = Color.White,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    lineHeight = 11.sp,
-                    modifier = Modifier
-                        .align(Alignment.BottomStart)
-                        .padding(6.dp)
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = characterRole,
+                    fontFamily = PoppinsRegular,
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // Información del actor de voz (derecha) - placeholder por ahora
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Actor de voz (placeholder)
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Text(
+                    text = "Actor de voz",
+                    fontFamily = PoppinsBold,
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = "Japonés",
+                    fontFamily = PoppinsRegular,
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Avatar del actor con inicial (placeholder)
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "A",
+                    fontFamily = PoppinsBold,
+                    fontSize = 18.sp,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
             }
         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.ui.draw.blur
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -39,12 +42,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import android.widget.Toast
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import java.net.URLEncoder
 import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import coil.size.Size
 import com.yumedev.seijakulist.domain.models.AnimeCharactersDetail
 import com.yumedev.seijakulist.domain.models.MangaDetail
 import com.yumedev.seijakulist.ui.components.LoadingScreen
@@ -59,14 +65,16 @@ import com.yumedev.seijakulist.ui.theme.asp
  * Pantalla de detalle del manga
  * Diseño consistente con Material Design 3 y el resto de la app
  */
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
 @Composable
 fun MangaDetailScreen(
     navController: NavController,
     mangaId: Int?,
     initialTab: Int = 0,
     mangaDetailViewModel: MangaDetailAniListViewModel = hiltViewModel(),
-    mangaCharacterDetailViewModel: MangaCharacterDetailViewModel = hiltViewModel()
+    mangaCharacterDetailViewModel: MangaCharacterDetailViewModel = hiltViewModel(),
+    sharedTransitionScope: SharedTransitionScope? = null,
+    animatedVisibilityScope: AnimatedVisibilityScope? = null
 ) {
     // ViewModels state
     val mangaDetail by mangaDetailViewModel.mangaDetail.collectAsState()
@@ -111,22 +119,7 @@ fun MangaDetailScreen(
 
         mangaDetail != null -> {
             Scaffold(
-                topBar = {
-                    CenterAlignedTopAppBar(
-                        title = { },
-                        navigationIcon = {
-                            IconButton(onClick = { navController.popBackStack() }) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                    contentDescription = "Volver"
-                                )
-                            }
-                        },
-                        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                            containerColor = MaterialTheme.colorScheme.background
-                        )
-                    )
-                },
+                containerColor = Color.Transparent,
                 floatingActionButton = {
                     AnimatedVisibility(
                         visible = showFab,
@@ -168,26 +161,83 @@ fun MangaDetailScreen(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background)
                         .pointerInput(Unit) {
                             detectTapGestures(onTap = { focusManager.clearFocus() })
                         }
                 ) {
+                    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+
+                    // CONTENIDO CON SCROLL
                     LazyColumn(
                         state = listState,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(
-                            top = paddingValues.calculateTopPadding(),
                             bottom = paddingValues.calculateBottomPadding()
                         )
                     ) {
-                        // Header con portada e información principal
+                        // BANNER CON BLUR + HEADER ENCIMA
                         item {
-                            MangaDetailHeader(mangaDetail = mangaDetail)
-                        }
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                            ) {
+                                // Banner image con blur (si existe)
+                                mangaDetail!!.bannerImage?.let { banner ->
+                                    if (!banner.contains("no-image", ignoreCase = true) && banner.isNotBlank()) {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .height(statusBarHeight + 320.dp)
+                                        ) {
+                                            // Banner image con blur
+                                            AsyncImage(
+                                                model = banner,
+                                                contentDescription = null,
+                                                modifier = Modifier
+                                                    .fillMaxSize()
+                                                    .blur(25.dp),
+                                                contentScale = ContentScale.Crop
+                                            )
 
-                        // Stats Cards
-                        item {
-                            MangaStatsRow(mangaDetail = mangaDetail)
+                                            // Gradient overlay
+                                            Box(
+                                                modifier = Modifier
+                                                    .fillMaxSize()
+                                                    .background(
+                                                        Brush.verticalGradient(
+                                                            colors = listOf(
+                                                                Color.Black.copy(alpha = 0.3f),
+                                                                Color.Black.copy(alpha = 0.4f),
+                                                                Color.Black.copy(alpha = 0.5f),
+                                                                MaterialTheme.colorScheme.background.copy(alpha = 0.8f),
+                                                                MaterialTheme.colorScheme.background
+                                                            )
+                                                        )
+                                                    )
+                                            )
+                                        }
+                                    }
+                                }
+
+                                // Header con portada e información (ENCIMA del banner)
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = statusBarHeight + 56.dp)
+                                ) {
+                                    MangaDetailHeader(
+                                        mangaDetail = mangaDetail,
+                                        isAdded = false, // TODO: Implementar estado isAdded en el ViewModel
+                                        onAddToListClick = {
+                                            // TODO: Navegar a añadir a lista
+                                        },
+                                        sharedTransitionScope = sharedTransitionScope,
+                                        animatedVisibilityScope = animatedVisibilityScope,
+                                        mangaId = mangaId
+                                    )
+                                }
+                            }
                         }
 
                         // Tab selector
@@ -237,6 +287,34 @@ fun MangaDetailScreen(
                             }
                         }
                     }
+
+                    // TOP BAR CON BOTONES (transparente, sobre el banner)
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(statusBarHeight + 56.dp)
+                            .align(Alignment.TopCenter)
+                    ) {
+                        // Botón de atrás (izquierda)
+                        Surface(
+                            shape = CircleShape,
+                            color = Color.Black.copy(alpha = 0.5f),
+                            modifier = Modifier
+                                .align(Alignment.BottomStart)
+                                .padding(start = 16.dp, bottom = 8.dp)
+                                .size(40.dp)
+                        ) {
+                            IconButton(
+                                onClick = { navController.popBackStack() }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                    contentDescription = "Volver",
+                                    tint = Color.White
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -247,10 +325,10 @@ fun MangaDetailScreen(
 // TABS
 // ============================================================================
 
-enum class MangaDetailTab {
-    OVERVIEW,
-    CHARACTERS,
-    INFO
+enum class MangaDetailTab(val title: String) {
+    OVERVIEW("Resumen"),
+    CHARACTERS("Reparto"),
+    INFO("Información")
 }
 
 @Composable
@@ -259,30 +337,29 @@ private fun MangaDetailTabSelector(
     onTabSelected: (MangaDetailTab) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // Siempre 3 tabs según el diseño: Resumen, Reparto, Información
     val tabs = listOf(
-        MangaDetailTab.OVERVIEW to Icons.Default.Description,
-        MangaDetailTab.CHARACTERS to Icons.Default.People,
-        MangaDetailTab.INFO to Icons.Default.Info
+        MangaDetailTab.OVERVIEW,
+        MangaDetailTab.CHARACTERS,
+        MangaDetailTab.INFO
     )
 
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(start = 16.dp, end = 16.dp, bottom = 20.dp, top = 8.dp),
+            .padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Card(
+        Surface(
             modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(24.dp),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-            ),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            shadowElevation = 0.dp
         ) {
             Row(modifier = Modifier.padding(4.dp)) {
-                tabs.forEach { (tab, icon) ->
+                tabs.forEach { tab ->
                     MangaTabItem(
-                        icon = icon,
+                        text = tab.title,
                         isSelected = selectedTab == tab,
                         onClick = { onTabSelected(tab) },
                         modifier = Modifier.weight(1f)
@@ -295,7 +372,7 @@ private fun MangaDetailTabSelector(
 
 @Composable
 private fun MangaTabItem(
-    icon: ImageVector,
+    text: String,
     isSelected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -305,29 +382,33 @@ private fun MangaTabItem(
             MaterialTheme.colorScheme.primary
         else
             Color.Transparent,
-        label = "Tab Background Color"
+        label = "Tab Background Color",
+        animationSpec = tween(200)
     )
-    val iconColor by animateColorAsState(
+    val textColor by animateColorAsState(
         targetValue = if (isSelected)
             MaterialTheme.colorScheme.onPrimary
         else
             MaterialTheme.colorScheme.onSurfaceVariant,
-        label = "Tab Icon Color"
+        label = "Tab Text Color",
+        animationSpec = tween(200)
     )
 
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(20.dp))
+            .clip(RoundedCornerShape(12.dp))
             .background(backgroundColor)
             .clickable { onClick() }
             .padding(vertical = 10.dp, horizontal = 12.dp),
         contentAlignment = Alignment.Center
     ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            modifier = Modifier.size(24.adp()),
-            tint = iconColor
+        Text(
+            text = text,
+            fontFamily = if (isSelected) PoppinsBold else PoppinsMedium,
+            fontSize = 13.sp,
+            color = textColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }
@@ -336,122 +417,144 @@ private fun MangaTabItem(
 // HEADER
 // ============================================================================
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 private fun MangaDetailHeader(
     mangaDetail: MangaDetail?,
+    isAdded: Boolean,
+    onAddToListClick: () -> Unit,
+    sharedTransitionScope: SharedTransitionScope?,
+    animatedVisibilityScope: AnimatedVisibilityScope?,
+    mangaId: Int?,
     modifier: Modifier = Modifier
 ) {
-    Column(
+    val context = LocalContext.current
+
+    Row(
         modifier = modifier
             .fillMaxWidth()
             .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Bottom
     ) {
-        // SECCIÓN PRINCIPAL: Portada + Info
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        // PORTADA (a la izquierda, más grande)
+        Card(
+            modifier = Modifier
+                .width(150.dp)
+                .height(215.dp),
+            shape = RoundedCornerShape(8.dp),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
         ) {
-            // PORTADA
-            Card(
-                modifier = Modifier
-                    .width(120.adp())
-                    .height(180.adp()),
-                shape = RoundedCornerShape(12.dp),
-                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+            val imageModifier = if (sharedTransitionScope != null &&
+                animatedVisibilityScope != null && mangaId != null
             ) {
-                AsyncImage(
-                    model = mangaDetail?.images ?: "",
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
+                with(sharedTransitionScope) {
+                    Modifier
+                        .sharedElement(
+                            sharedContentState = rememberSharedContentState(
+                                key = "manga-image-$mangaId"
+                            ),
+                            animatedVisibilityScope = animatedVisibilityScope
+                        )
                         .fillMaxSize()
-                        .clip(RoundedCornerShape(12.dp))
-                )
+                        .clip(RoundedCornerShape(8.dp))
+                }
+            } else {
+                Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(8.dp))
             }
 
-            // INFORMACIÓN PRINCIPAL
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(mangaDetail?.images ?: "")
+                    .size(Size.ORIGINAL)
+                    .crossfade(false)
+                    .build(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = imageModifier
+            )
+        }
+
+        // INFORMACIÓN A LA DERECHA (alineada al bottom)
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
             Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(180.adp()),
-                verticalArrangement = Arrangement.SpaceBetween
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                // TÍTULOS Y ESTADO
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    // Título principal
+                // Título principal
+                Text(
+                    text = mangaDetail?.title ?: "",
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 22.sp,
+                    fontFamily = PoppinsBold,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                    lineHeight = 26.sp
+                )
+
+                // Título japonés
+                if (!mangaDetail?.titleJapanese.isNullOrBlank()) {
                     Text(
-                        text = mangaDetail?.title ?: "",
-                        color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 18.asp(),
-                        fontFamily = PoppinsBold,
-                        maxLines = 3,
-                        overflow = TextOverflow.Ellipsis,
-                        lineHeight = 22.asp()
+                        text = mangaDetail.titleJapanese,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                        fontSize = 14.sp,
+                        fontFamily = PoppinsRegular,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
-
-                    // Título japonés
-                    if (!mangaDetail?.titleJapanese.isNullOrBlank()) {
-                        Text(
-                            text = mangaDetail.titleJapanese,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            fontSize = 12.asp(),
-                            fontFamily = PoppinsRegular,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-
-                    // Type y Status badges
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        // Type badge
-                        MangaTypeBadge(type = mangaDetail?.typeManga ?: "")
-
-                        // Status badge
-                        MangaStatusBadge(status = mangaDetail?.status ?: "")
-                    }
                 }
 
-                // BOTÓN DE ACCIÓN MEJORADO
-                Button(
-                    onClick = { /* TODO: Añadir a lista */ },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(48.dp), // Más alto
-                    shape = RoundedCornerShape(14.dp), // Más redondeado
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary
-                    ),
-                    elevation = ButtonDefaults.buttonElevation(
-                        defaultElevation = 4.dp, // Mayor elevación
-                        pressedElevation = 8.dp
-                    )
+                // Type y Status badges
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Favorite,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp) // Icono más grande
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = "Añadir",
-                        fontSize = 15.sp, // Texto más grande
-                        fontFamily = PoppinsBold,
-                        letterSpacing = 0.3.sp
-                    )
+                    // Type badge
+                    MangaTypeBadge(type = mangaDetail?.typeManga ?: "")
+
+                    // Status badge
+                    MangaStatusBadge(status = mangaDetail?.status ?: "")
                 }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Botón "Añadir a mi lista" o "Editar"
+            Button(
+                onClick = onAddToListClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(44.dp),
+                shape = RoundedCornerShape(50),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                ),
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp)
+            ) {
+                Icon(
+                    imageVector = if (isAdded) Icons.Default.Edit else Icons.Default.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = if (isAdded) "Editar" else "Añadir a mi lista",
+                    fontSize = 14.sp,
+                    fontFamily = PoppinsBold
+                )
             }
         }
     }
 }
 
 // ============================================================================
-// STATS ROW
+// STATS ROW (Ya no se necesita, el header incluye las stats)
 // ============================================================================
 
+/*
 @Composable
 private fun MangaStatsRow(
     mangaDetail: MangaDetail?,
@@ -676,6 +779,7 @@ private fun MangaStatCard(
         }
     }
 }
+*/
 
 // ============================================================================
 // TAB CONTENTS
@@ -1319,40 +1423,32 @@ private fun MangaInfoRow(
 private fun MangaTypeBadge(type: String) {
     if (type.isBlank()) return
 
-    // Mapeo de tipos de manga con colores específicos
-    val (icon, color) = when (type) {
-        "MANGA" -> Icons.Default.Book to Color(0xFF2196F3) // Azul
-        "NOVEL" -> Icons.Default.MenuBook to Color(0xFF9C27B0) // Púrpura
-        "ONE_SHOT" -> Icons.Default.Description to Color(0xFF00BCD4) // Cian
-        "MANHWA" -> Icons.Default.Book to Color(0xFFFF5722) // Naranja rojizo (Corea)
-        "MANHUA" -> Icons.Default.Book to Color(0xFFF44336) // Rojo (China)
-        else -> Icons.Default.Book to Color(0xFF2196F3) // Azul por defecto
+    // Colores según el tipo
+    val color = when (type) {
+        "MANGA" -> Color(0xFF2196F3) // Azul
+        "NOVEL" -> Color(0xFF9C27B0) // Púrpura
+        "ONE_SHOT" -> Color(0xFF00BCD4) // Cian
+        "MANHWA" -> Color(0xFFFF5722) // Naranja rojizo (Corea)
+        "MANHUA" -> Color(0xFFF44336) // Rojo (China)
+        else -> Color(0xFF2196F3) // Azul por defecto
     }
 
     Surface(
-        shape = RoundedCornerShape(8.dp),
-        color = color.copy(alpha = 0.15f),
-        border = androidx.compose.foundation.BorderStroke(1.dp, color.copy(alpha = 0.5f))
+        shape = RoundedCornerShape(50), // Completamente redondeado (pill)
+        color = color.copy(alpha = 0.2f),
+        border = androidx.compose.foundation.BorderStroke(
+            width = 1.5.dp,
+            color = color.copy(alpha = 0.5f)
+        )
     ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(14.dp),
-                tint = color
-            )
-            Text(
-                text = formatMangaType(type),
-                fontFamily = PoppinsBold,
-                fontSize = 11.sp,
-                color = color,
-                letterSpacing = 0.3.sp
-            )
-        }
+        Text(
+            text = formatMangaType(type),
+            fontFamily = PoppinsBold,
+            fontSize = 11.sp,
+            color = color,
+            letterSpacing = 0.3.sp,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+        )
     }
 }
 
@@ -1360,55 +1456,34 @@ private fun MangaTypeBadge(type: String) {
 private fun MangaStatusBadge(status: String) {
     if (status.isBlank()) return
 
-    // Mapeo completo de todos los estados posibles de AniList API para manga
-    val (text, icon, color) = when (status) {
-        "FINISHED" -> Triple(
-            "Completado",
-            Icons.Default.CheckCircle,
-            Color(0xFF4CAF50) // Verde - completado
-        )
-        "RELEASING" -> Triple(
-            "En publicación",
-            Icons.Default.FiberManualRecord,
-            Color(0xFF2196F3) // Azul - activo
-        )
-        "NOT_YET_RELEASED" -> Triple(
-            "Próximamente",
-            Icons.Default.Schedule,
-            Color(0xFF9C27B0) // Púrpura - futuro
-        )
-        "CANCELLED" -> Triple(
-            "Cancelado",
-            Icons.Default.Cancel,
-            Color(0xFFF44336) // Rojo - error/cancelado
-        )
-        "HIATUS" -> Triple(
-            "En pausa",
-            Icons.Default.Pause,
-            Color(0xFFFF9800) // Naranja - pausado
-        )
-        else -> Triple(
-            status,
-            Icons.Default.Info,
-            Color(0xFF757575) // Gris - desconocido
-        )
+    val (text, color) = when (status) {
+        "FINISHED" -> "Completado" to Color(0xFF7EE787)
+        "RELEASING" -> "En publicación" to Color(0xFF00A8FF)
+        "NOT_YET_RELEASED" -> "Próximamente" to Color(0xFF79C0FF)
+        "CANCELLED" -> "Cancelado" to Color(0xFFFF7B72)
+        "HIATUS" -> "En pausa" to Color(0xFFFF9800)
+        else -> status to Color(0xFF757575)
     }
 
     Surface(
-        shape = RoundedCornerShape(8.dp),
-        color = color.copy(alpha = 0.15f),
-        border = androidx.compose.foundation.BorderStroke(1.dp, color.copy(alpha = 0.5f))
+        shape = RoundedCornerShape(50), // Completamente redondeado (pill)
+        color = color.copy(alpha = 0.2f),
+        border = androidx.compose.foundation.BorderStroke(
+            width = 1.5.dp,
+            color = color.copy(alpha = 0.5f)
+        )
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(if (status == "RELEASING") 10.dp else 14.dp),
-                tint = color
+            // Dot indicator
+            Box(
+                modifier = Modifier
+                    .size(6.dp)
+                    .clip(CircleShape)
+                    .background(color)
             )
             Text(
                 text = text,

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
@@ -803,127 +803,109 @@ private fun MangaOverviewTab(
             val clipboardManager = LocalClipboardManager.current
             var expanded by remember { mutableStateOf(false) }
 
-            Card(
+            Column(
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(12.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                ),
-                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                        .animateContentSize(),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                // Header con título y botones de acción
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    // Header con título y botones de acción
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Sinopsis",
-                            fontSize = 21.sp,
-                            fontFamily = PoppinsBold,
-                            fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
-                            letterSpacing = 0.3.sp,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-
-                        // Botones de acción
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            // Botón de copiar
-                            FilledTonalIconButton(
-                                onClick = {
-                                    clipboardManager.setText(AnnotatedString(mangaDetail.synopsis))
-                                    Toast.makeText(
-                                        context,
-                                        "Sinopsis copiada al portapapeles",
-                                        Toast.LENGTH_SHORT
-                                    ).show()
-                                },
-                                modifier = Modifier.size(36.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.ContentCopy,
-                                    contentDescription = "Copiar sinopsis",
-                                    modifier = Modifier.size(18.dp)
-                                )
-                            }
-
-                            // Botón de traducir
-                            FilledTonalIconButton(
-                                onClick = {
-                                    val synopsis = mangaDetail.synopsis
-                                    val textToTranslate = if (synopsis.length > 2000) {
-                                        synopsis.substring(0, 2000) + "..."
-                                    } else {
-                                        synopsis
-                                    }
-                                    val encodedText = URLEncoder.encode(textToTranslate, "UTF-8")
-                                    val url = "https://translate.google.com/m?sl=en&tl=es&q=$encodedText"
-
-                                    val customTabsIntent = CustomTabsIntent.Builder()
-                                        .setShowTitle(true)
-                                        .build()
-                                    customTabsIntent.launchUrl(context, Uri.parse(url))
-                                },
-                                modifier = Modifier.size(36.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Translate,
-                                    contentDescription = "Traducir sinopsis",
-                                    modifier = Modifier.size(18.dp)
-                                )
-                            }
-                        }
-                    }
-
-                    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
-                    val hasOverflow = textLayoutResult?.hasVisualOverflow ?: false
-
                     Text(
-                        text = mangaDetail.synopsis,
-                        fontFamily = PoppinsRegular,
-                        fontSize = 14.sp,
-                        lineHeight = 23.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = if (expanded) TextAlign.Justify else TextAlign.Start,
-                        maxLines = if (expanded) Int.MAX_VALUE else 6,
-                        overflow = TextOverflow.Ellipsis,
-                        onTextLayout = { textLayoutResult = it }
+                        text = "Sinopsis",
+                        fontSize = 16.sp,
+                        fontFamily = PoppinsBold,
+                        color = MaterialTheme.colorScheme.onSurface
                     )
 
-                    if (hasOverflow || expanded) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.Center
+                    // Botones de acción
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        // Botón de copiar
+                        IconButton(
+                            onClick = {
+                                clipboardManager.setText(AnnotatedString(mangaDetail.synopsis))
+                                Toast.makeText(
+                                    context,
+                                    "Sinopsis copiada",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            },
+                            modifier = Modifier.size(32.dp)
                         ) {
-                            FilledTonalButton(
-                                onClick = { expanded = !expanded },
-                                shape = RoundedCornerShape(12.dp)
-                            ) {
-                                Icon(
-                                    imageVector = if (expanded)
-                                        Icons.Default.ExpandLess
-                                    else
-                                        Icons.Default.ExpandMore,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp)
-                                )
-                                Spacer(modifier = Modifier.width(6.dp))
-                                Text(
-                                    text = if (expanded) "Ver menos" else "Ver más",
-                                    fontFamily = PoppinsBold,
-                                    fontSize = 13.sp
-                                )
-                            }
+                            Icon(
+                                imageVector = Icons.Default.ContentCopy,
+                                contentDescription = "Copiar sinopsis",
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
+
+                        // Botón de traducir
+                        IconButton(
+                            onClick = {
+                                val synopsis = mangaDetail.synopsis
+                                val textToTranslate = if (synopsis.length > 2000) {
+                                    synopsis.substring(0, 2000) + "..."
+                                } else {
+                                    synopsis
+                                }
+                                val encodedText = URLEncoder.encode(textToTranslate, "UTF-8")
+                                val url = "https://translate.google.com/m?sl=en&tl=es&q=$encodedText"
+
+                                val customTabsIntent = CustomTabsIntent.Builder()
+                                    .setShowTitle(true)
+                                    .build()
+                                customTabsIntent.launchUrl(context, Uri.parse(url))
+                            },
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Translate,
+                                contentDescription = "Traducir sinopsis",
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+
+                var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+                val hasOverflow = textLayoutResult?.hasVisualOverflow ?: false
+
+                Text(
+                    text = mangaDetail.synopsis,
+                    fontFamily = PoppinsRegular,
+                    fontSize = 14.sp,
+                    lineHeight = 21.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = if (expanded) Int.MAX_VALUE else 6,
+                    overflow = TextOverflow.Ellipsis,
+                    onTextLayout = { textLayoutResult = it },
+                    modifier = Modifier.animateContentSize()
+                )
+
+                if (hasOverflow || expanded) {
+                    TextButton(
+                        onClick = { expanded = !expanded },
+                        modifier = Modifier.align(Alignment.Start)
+                    ) {
+                        Text(
+                            text = if (expanded) "ver menos" else "ver más",
+                            fontFamily = PoppinsMedium,
+                            fontSize = 13.sp
+                        )
+                        Icon(
+                            imageVector = if (expanded)
+                                Icons.Default.ExpandLess
+                            else
+                                Icons.Default.ExpandMore,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
@@ -92,6 +92,10 @@ fun MangaDetailScreen(
     var selectedTab by remember { mutableStateOf(MangaDetailTab.OVERVIEW) }
     val focusManager = LocalFocusManager.current
     val listState = rememberLazyListState()
+    val context = LocalContext.current
+
+    // Modal Bottom Sheet state
+    var showAddToListSheet by remember { mutableStateOf(false) }
 
     // FAB visibility based on scroll
     val showFab by remember {
@@ -131,7 +135,7 @@ fun MangaDetailScreen(
                         exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
                     ) {
                         ExtendedFloatingActionButton(
-                            onClick = { /* TODO: Añadir a lista */ },
+                            onClick = { showAddToListSheet = true },
                             icon = {
                                 Icon(
                                     imageVector = Icons.Default.Favorite,
@@ -234,7 +238,7 @@ fun MangaDetailScreen(
                                         mangaDetail = mangaDetail,
                                         isAdded = false, // TODO: Implementar estado isAdded en el ViewModel
                                         onAddToListClick = {
-                                            // TODO: Navegar a añadir a lista
+                                            showAddToListSheet = true
                                         },
                                         sharedTransitionScope = sharedTransitionScope,
                                         animatedVisibilityScope = animatedVisibilityScope,
@@ -318,6 +322,90 @@ fun MangaDetailScreen(
                                 )
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    // Modal Bottom Sheet para añadir/editar manga en la lista (Dialog personalizado sin drag)
+    if (showAddToListSheet && mangaDetail != null) {
+        androidx.compose.ui.window.Dialog(
+            onDismissRequest = { showAddToListSheet = false },
+            properties = androidx.compose.ui.window.DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true,
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = false
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.5f))
+                    .clickable(
+                        onClick = { showAddToListSheet = false },
+                        indication = null,
+                        interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
+                    ),
+                contentAlignment = Alignment.BottomCenter
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight(0.85f)
+                        .clickable(
+                            onClick = { },
+                            indication = null,
+                            interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
+                        ),
+                    shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    Column {
+                        // Drag handle visual (no funcional)
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .width(32.dp)
+                                    .height(4.dp)
+                                    .background(
+                                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                        RoundedCornerShape(2.dp)
+                                    )
+                            )
+                        }
+
+                        // Contenido del modal
+                        com.yumedev.seijakulist.ui.screens.add_to_list.AddToListMangaModalContent(
+                            manga = mangaDetail,
+                            existingManga = null, // TODO: Implementar obtención del manga existente
+                            isAdded = false, // TODO: Implementar estado isAdded
+                            onDismiss = { showAddToListSheet = false },
+                            onSave = { status, rating, chapter, volume, rereading, note ->
+                                // TODO: Implementar lógica de guardado
+                                android.widget.Toast.makeText(
+                                    context,
+                                    "Guardado: $status - Rating: $rating - Cap: $chapter - Vol: $volume",
+                                    android.widget.Toast.LENGTH_SHORT
+                                ).show()
+                                showAddToListSheet = false
+                            },
+                            onDelete = {
+                                // TODO: Implementar lógica de eliminación
+                                android.widget.Toast.makeText(
+                                    context,
+                                    "Manga eliminado de tu lista",
+                                    android.widget.Toast.LENGTH_SHORT
+                                ).show()
+                                showAddToListSheet = false
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
@@ -391,10 +391,10 @@ fun MangaDetailScreen(
                                 // TODO: Implementar lógica de guardado
                                 android.widget.Toast.makeText(
                                     context,
-                                    "Guardado: $status - Rating: $rating - Cap: $chapter - Vol: $volume",
+                                    "Manga guardado en tu lista",
                                     android.widget.Toast.LENGTH_SHORT
                                 ).show()
-                                showAddToListSheet = false
+                                // El dismiss se maneja en el componente modal
                             },
                             onDelete = {
                                 // TODO: Implementar lógica de eliminación
@@ -403,7 +403,7 @@ fun MangaDetailScreen(
                                     "Manga eliminado de tu lista",
                                     android.widget.Toast.LENGTH_SHORT
                                 ).show()
-                                showAddToListSheet = false
+                                // El dismiss se maneja en el componente modal
                             }
                         )
                     }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/MangaDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.ui.draw.blur
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -1258,76 +1259,140 @@ private fun MangaInfoTab(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+            .padding(horizontal = 16.dp)
     ) {
-        // Basic info
-        MangaInfoRow("Título en inglés", mangaDetail?.titleEnglish?.ifBlank { "—" } ?: "—")
-        MangaInfoRow("Título japonés", mangaDetail?.titleJapanese?.ifBlank { "—" } ?: "—")
-        MangaInfoRow("Tipo", formatMangaType(mangaDetail?.typeManga ?: ""))
-        MangaInfoRow("Estado", formatMangaStatus(mangaDetail?.status ?: ""))
+        // Basic info - filas simples con dividers
+        MangaSimpleInfoRow("Título en inglés", mangaDetail?.titleEnglish?.ifBlank { "—" } ?: "—")
+        HorizontalDivider(
+            modifier = Modifier.padding(vertical = 12.dp),
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+        )
+
+        MangaSimpleInfoRow("Título japonés", mangaDetail?.titleJapanese?.ifBlank { "—" } ?: "—")
+        HorizontalDivider(
+            modifier = Modifier.padding(vertical = 12.dp),
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+        )
+
+        MangaSimpleInfoRow("Tipo", formatMangaType(mangaDetail?.typeManga ?: ""))
+        HorizontalDivider(
+            modifier = Modifier.padding(vertical = 12.dp),
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+        )
+
+        // Estado con dot indicator
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Estado",
+                fontFamily = PoppinsRegular,
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(6.dp)
+                        .clip(CircleShape)
+                        .background(
+                            when (mangaDetail?.status) {
+                                "RELEASING" -> Color(0xFF00A8FF)
+                                "FINISHED" -> Color(0xFF7EE787)
+                                else -> MaterialTheme.colorScheme.onSurface
+                            }
+                        )
+                )
+                Text(
+                    text = formatMangaStatus(mangaDetail?.status ?: ""),
+                    fontFamily = PoppinsBold,
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.End
+                )
+            }
+        }
 
         if (mangaDetail?.chapters != null && mangaDetail.chapters > 0) {
-            MangaInfoRow("Capítulos", "${mangaDetail.chapters}")
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 12.dp),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+            )
+            MangaSimpleInfoRow("Capítulos", "${mangaDetail.chapters}")
         }
 
         if (mangaDetail?.volumes != null && mangaDetail.volumes > 0) {
-            MangaInfoRow("Volúmenes", "${mangaDetail.volumes}")
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 12.dp),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+            )
+            MangaSimpleInfoRow("Volúmenes", "${mangaDetail.volumes}")
         }
 
         if (!mangaDetail?.published.isNullOrBlank()) {
-            MangaInfoRow("Publicación", mangaDetail.published)
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 12.dp),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+            )
+            MangaSimpleInfoRow("Publicación", mangaDetail.published)
         }
 
         if (mangaDetail?.score != null && mangaDetail.score > 0) {
-            MangaInfoRow("Puntuación", "${mangaDetail.score}/10")
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 12.dp),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+            )
+            MangaSimpleInfoRow("Puntuación", "${mangaDetail.score} / 10")
         }
 
         if (mangaDetail?.scoreBy != null && mangaDetail.scoreBy > 0) {
-            MangaInfoRow("Valoraciones", "${mangaDetail.scoreBy} usuarios")
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 12.dp),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+            )
+            MangaSimpleInfoRow("Valoraciones", "${mangaDetail.scoreBy} usuarios")
         }
 
-        // Serializations - en formato pill con colores
+        // Serializations - mismo estilo que Studios/Producers del anime
         if (!mangaDetail?.serializations.isNullOrEmpty()) {
             Spacer(modifier = Modifier.height(8.dp))
-            MangaInfoCard(title = "Publicado en") {
-                // Paleta de colores para los chips
-                val chipColors = listOf(
-                    Color(0xFF2196F3), // Azul
-                    Color(0xFF9C27B0), // Púrpura
-                    Color(0xFF00BCD4), // Cian
-                    Color(0xFFFF5722), // Naranja rojizo
-                    Color(0xFF4CAF50), // Verde
-                    Color(0xFFFF9800), // Naranja
-                    Color(0xFFE91E63), // Rosa
-                    Color(0xFF009688)  // Teal
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "Publicado en",
+                    fontFamily = PoppinsBold,
+                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
 
-                androidx.compose.foundation.layout.FlowRow(
+                FlowRow(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    mangaDetail.serializations.forEachIndexed { index, serialization ->
-                        val chipColor = chipColors[index % chipColors.size]
-
-                        Surface(
-                            shape = RoundedCornerShape(20.dp),
-                            color = chipColor.copy(alpha = 0.15f),
-                            border = androidx.compose.foundation.BorderStroke(
-                                1.dp,
-                                chipColor.copy(alpha = 0.5f)
-                            )
-                        ) {
-                            Text(
-                                text = serialization.name,
-                                fontFamily = PoppinsBold,
-                                fontSize = 12.sp,
-                                color = chipColor,
-                                modifier = Modifier.padding(horizontal = 14.dp, vertical = 6.dp)
-                            )
+                    mangaDetail.serializations.filterNotNull()
+                        .filter { !it.name.isNullOrBlank() }
+                        .forEach { serialization ->
+                            Surface(
+                                shape = RoundedCornerShape(20.dp),
+                                color = MaterialTheme.colorScheme.surfaceContainerHigh
+                            ) {
+                                Text(
+                                    text = serialization.name,
+                                    fontFamily = PoppinsMedium,
+                                    fontSize = 13.sp,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp)
+                                )
+                            }
                         }
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/components/header/MangaDetailHeader.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/components/header/MangaDetailHeader.kt
@@ -1,0 +1,351 @@
+package com.yumedev.seijakulist.ui.screens.detail.components.header
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import coil.size.Size
+import com.yumedev.seijakulist.domain.models.MangaDetail
+import com.yumedev.seijakulist.ui.screens.detail.components.shared.StatusChip
+import com.yumedev.seijakulist.ui.theme.PoppinsBold
+import com.yumedev.seijakulist.ui.theme.PoppinsMedium
+import com.yumedev.seijakulist.ui.theme.PoppinsRegular
+import com.yumedev.seijakulist.ui.theme.adp
+import com.yumedev.seijakulist.ui.theme.asp
+
+/**
+ * Header limpio del detalle del manga
+ * Layout: Portada + Información organizada en columna
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun MangaDetailHeader(
+    mangaDetail: MangaDetail?,
+    displayImageUrl: String,
+    isAdded: Boolean,
+    onAddToListClick: () -> Unit,
+    sharedTransitionScope: SharedTransitionScope? = null,
+    animatedVisibilityScope: AnimatedVisibilityScope? = null,
+    mangaId: Int? = null
+) {
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // SECCIÓN PRINCIPAL: Portada + Info
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // PORTADA
+            Card(
+                modifier = Modifier
+                    .width(120.adp())
+                    .height(180.adp()),
+                shape = RoundedCornerShape(12.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+            ) {
+                val imageModifier = if (sharedTransitionScope != null &&
+                    animatedVisibilityScope != null && mangaId != null
+                ) {
+                    with(sharedTransitionScope) {
+                        Modifier
+                            .sharedElement(
+                                sharedContentState = rememberSharedContentState(
+                                    key = "manga-image-$mangaId"
+                                ),
+                                animatedVisibilityScope = animatedVisibilityScope
+                            )
+                            .fillMaxSize()
+                            .clip(RoundedCornerShape(12.dp))
+                    }
+                } else {
+                    Modifier
+                        .fillMaxSize()
+                        .clip(RoundedCornerShape(12.dp))
+                }
+
+                AsyncImage(
+                    model = ImageRequest.Builder(context)
+                        .data(displayImageUrl)
+                        .size(Size.ORIGINAL)
+                        .crossfade(false)
+                        .build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = imageModifier
+                )
+            }
+
+            // INFORMACIÓN PRINCIPAL
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(180.adp()),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                // TÍTULOS Y ESTADO
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    // Título principal
+                    Text(
+                        text = mangaDetail?.title ?: "",
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontSize = 18.asp(),
+                        fontFamily = PoppinsBold,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                        lineHeight = 22.asp()
+                    )
+
+                    // Título japonés
+                    if (!mangaDetail?.titleJapanese.isNullOrBlank()) {
+                        Text(
+                            text = mangaDetail.titleJapanese,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 12.asp(),
+                            fontFamily = PoppinsRegular,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    // Status chip
+                    StatusChip(mangaDetail?.status ?: "")
+                }
+
+                // BOTÓN DE ACCIÓN
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    // Botón Añadir/Editar
+                    Button(
+                        onClick = onAddToListClick,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(40.dp),
+                        shape = RoundedCornerShape(10.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (isAdded)
+                                MaterialTheme.colorScheme.secondaryContainer
+                            else
+                                MaterialTheme.colorScheme.primary
+                        )
+                    ) {
+                        Icon(
+                            imageVector = if (isAdded) Icons.Default.Edit else Icons.Default.Favorite,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = if (isAdded) "Editar" else "Añadir",
+                            fontSize = 13.asp(),
+                            fontFamily = PoppinsBold
+                        )
+                    }
+                }
+            }
+        }
+
+        // STATS CARDS: Score, Ranking, etc.
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                // Score
+                if (mangaDetail?.score != null && mangaDetail.score > 0) {
+                    StatItem(
+                        icon = Icons.Default.Star,
+                        label = "Score",
+                        value = String.format(java.util.Locale.US, "%.1f", mangaDetail.score),
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                // Rank
+                if (mangaDetail?.rank != null && mangaDetail.rank > 0) {
+                    StatItem(
+                        icon = Icons.Default.BarChart,
+                        label = "Rank",
+                        value = "#${mangaDetail.rank}",
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                // Popularity/Users
+                if (mangaDetail?.scoreBy != null && mangaDetail.scoreBy > 0) {
+                    StatItem(
+                        icon = Icons.Default.People,
+                        label = "Usuarios",
+                        value = formatNumber(mangaDetail.scoreBy),
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+        }
+
+        // QUICK INFO CHIPS
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            // Type
+            if (!mangaDetail?.typeManga.isNullOrBlank()) {
+                InfoChip(
+                    icon = Icons.Default.MenuBook,
+                    text = mangaDetail!!.typeManga
+                )
+            }
+
+            // Chapters
+            if (mangaDetail?.chapters != null && mangaDetail.chapters > 0) {
+                InfoChip(
+                    icon = Icons.Default.Article,
+                    text = "${mangaDetail.chapters} capítulos"
+                )
+            }
+
+            // Volumes
+            if (mangaDetail?.volumes != null && mangaDetail.volumes > 0) {
+                InfoChip(
+                    icon = Icons.Default.Book,
+                    text = "${mangaDetail.volumes} volúmenes"
+                )
+            }
+
+            // Published
+            if (!mangaDetail?.published.isNullOrBlank()) {
+                InfoChip(
+                    icon = Icons.Default.CalendarMonth,
+                    text = mangaDetail.published
+                )
+            }
+
+            // Demographics
+            mangaDetail?.demographics?.filterNotNull()?.take(2)?.forEach { demographic ->
+                InfoChip(
+                    icon = Icons.Default.People,
+                    text = demographic.name ?: "",
+                    highlighted = true
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatItem(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = value,
+            fontSize = 16.asp(),
+            fontFamily = PoppinsBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = label,
+            fontSize = 11.asp(),
+            fontFamily = PoppinsRegular,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun InfoChip(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    text: String,
+    highlighted: Boolean = false
+) {
+    Surface(
+        shape = RoundedCornerShape(20.dp),
+        color = if (highlighted)
+            MaterialTheme.colorScheme.primaryContainer
+        else
+            MaterialTheme.colorScheme.surfaceContainerHigh,
+        border = if (highlighted)
+            androidx.compose.foundation.BorderStroke(
+                1.dp,
+                MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
+            )
+        else null
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+                tint = if (highlighted)
+                    MaterialTheme.colorScheme.primary
+                else
+                    MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = text,
+                fontSize = 12.asp(),
+                fontFamily = PoppinsMedium,
+                color = if (highlighted)
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                else
+                    MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+private fun formatNumber(number: Int): String {
+    return when {
+        number >= 1_000_000 -> String.format(java.util.Locale.US, "%.1fM", number / 1_000_000.0)
+        number >= 1_000 -> String.format(java.util.Locale.US, "%.1fK", number / 1_000.0)
+        else -> number.toString()
+    }
+}

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/components/shared/AnimeDetailComponents.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/detail/components/shared/AnimeDetailComponents.kt
@@ -291,11 +291,12 @@ fun CompactDemographicCard(
 }
 
 /**
- * Badge de estado de emisión (Currently Airing, Finished Airing, etc.)
+ * Badge de estado de emisión/publicación (Anime y Manga)
  */
 @Composable
 fun StatusChip(status: String) {
     val (statusBg, statusFg, dotColor) = when (status) {
+        // Estados de Anime
         "Currently Airing" -> Triple(
             MaterialTheme.colorScheme.surfaceContainerHigh,
             Color(0xFF66BB6A),
@@ -311,6 +312,34 @@ fun StatusChip(status: String) {
             Color(0xFFFFA726),
             Color(0xFFFFA726)
         )
+
+        // Estados de Manga
+        "RELEASING", "Publishing" -> Triple(
+            MaterialTheme.colorScheme.surfaceContainerHigh,
+            Color(0xFF66BB6A),
+            Color(0xFF66BB6A)
+        )
+        "FINISHED", "Finished" -> Triple(
+            MaterialTheme.colorScheme.surfaceContainerHigh,
+            Color(0xFF42A5F5),
+            Color(0xFF42A5F5)
+        )
+        "NOT_YET_RELEASED", "Not yet published" -> Triple(
+            MaterialTheme.colorScheme.surfaceContainerHigh,
+            Color(0xFFFFA726),
+            Color(0xFFFFA726)
+        )
+        "CANCELLED", "Cancelled" -> Triple(
+            MaterialTheme.colorScheme.surfaceContainerHigh,
+            Color(0xFFF44336),
+            Color(0xFFF44336)
+        )
+        "HIATUS", "On Hiatus" -> Triple(
+            MaterialTheme.colorScheme.surfaceContainerHigh,
+            Color(0xFFAB47BC),
+            Color(0xFFAB47BC)
+        )
+
         else -> Triple(
             MaterialTheme.colorScheme.surfaceContainerHigh,
             Color.White,

--- a/app/src/main/java/com/yumedev/seijakulist/ui/screens/my_animes/MyAnimesScreen.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/ui/screens/my_animes/MyAnimesScreen.kt
@@ -83,8 +83,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.ProgressIndicatorDefaults
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -170,7 +168,7 @@ fun MyAnimeListScreen(
     )
 
     val scope = rememberCoroutineScope()
-    val snackbarHostState = remember { SnackbarHostState() }
+    val context = androidx.compose.ui.platform.LocalContext.current
 
     val statusAnime = listOf("Viendo", "Completado", "Pendiente", "Abandonado", "Planeado")
 
@@ -194,13 +192,12 @@ fun MyAnimeListScreen(
             // Activar el glow
             glowingAnimeId = event.animeId
 
-            // Mostrar snackbar
-            scope.launch {
-                snackbarHostState.showSnackbar(
-                    message = "¡Completado! Tu anime numero ${event.totalCompleted}",
-                    duration = SnackbarDuration.Short
-                )
-            }
+            // Mostrar toast
+            android.widget.Toast.makeText(
+                context,
+                "¡Completado! Tu anime numero ${event.totalCompleted}",
+                android.widget.Toast.LENGTH_SHORT
+            ).show()
 
             // Desactivar el glow después de 1.5 segundos
             delay(1500)
@@ -1082,22 +1079,6 @@ fun MyAnimeListScreen(
         }
         }
 
-        // SnackbarHost para mostrar el mensaje de completado
-        androidx.compose.material3.SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(bottom = 90.dp)
-        ) { snackbarData ->
-            androidx.compose.material3.Snackbar(
-                snackbarData = snackbarData,
-                containerColor = MaterialTheme.colorScheme.inverseSurface,
-                contentColor = MaterialTheme.colorScheme.inverseOnSurface,
-                actionColor = MaterialTheme.colorScheme.inversePrimary,
-                shape = RoundedCornerShape(12.dp)
-            )
-        }
-
         // Botón flotante de "volver arriba" - solo visible cuando hay contenido para mostrar
         if (!isLoading && savedAnimes.isNotEmpty()) {
             AnimatedVisibility(
@@ -1186,13 +1167,11 @@ fun MyAnimeListScreen(
             },
             onConfirm = {
                 viewModel.deleteAnimeToList(animeIdToDelete)
-                scope.launch {
-                    snackbarHostState.showSnackbar(
-                        message = "Anime eliminado de tu lista",
-                        actionLabel = "Deshacer",
-                        duration = SnackbarDuration.Long
-                    )
-                }
+                android.widget.Toast.makeText(
+                    context,
+                    "Anime eliminado de tu lista",
+                    android.widget.Toast.LENGTH_SHORT
+                ).show()
             },
             onDismiss = {
                 // Solo cierra el diálogo

--- a/app/src/main/java/com/yumedev/seijakulist/util/TranslationUtils.kt
+++ b/app/src/main/java/com/yumedev/seijakulist/util/TranslationUtils.kt
@@ -17,13 +17,22 @@ fun translateSeason(season: String): String {
 }
 
 /**
- * Traduce el estado de emisión del anime del inglés al español
+ * Traduce el estado de emisión del anime/manga del inglés al español
  */
 fun translateStatus(status: String): String {
     return when (status) {
+        // Estados de Anime
         "Currently Airing" -> "Actualmente en emisión"
         "Finished Airing" -> "Finalizado"
         "Not yet aired" -> "Próximamente"
+
+        // Estados de Manga
+        "FINISHED", "Finished" -> "Finalizado"
+        "RELEASING", "Publishing" -> "En publicación"
+        "NOT_YET_RELEASED", "Not yet published" -> "Próximamente"
+        "CANCELLED", "Cancelled" -> "Cancelado"
+        "HIATUS", "On Hiatus" -> "En pausa"
+
         else -> status
     }
 }


### PR DESCRIPTION
# Manga Detail Redesign and Add to List Bottom Sheet

## Overview

This PR delivers a complete redesign of the Manga Detail experience, improving the overall visual hierarchy, readability, and navigation flow. It also introduces a reusable **Add to List** bottom sheet, replacing the previous full-screen flow with a more integrated user experience across both Anime and Manga detail screens.

## What's New

### Manga Detail Redesign

Completely redesigned the Manga Detail screen with a more modern and immersive interface.

Improvements include:

- Blurred banner header for enhanced visual presentation.
- Refined layout and spacing.
- Improved typography and component hierarchy.
- Better consistency with the application's design system.

### Information Section

Redesigned the information section with:

- Improved content organization.
- Cleaner metadata presentation.
- Better visual consistency and readability.

### Synopsis

Refined the synopsis section by:

- Improving spacing and typography.
- Enhancing readability for long descriptions.
- Creating a cleaner reading experience.

### Genres and Authors

Updated the genres and authors sections with:

- Cleaner layouts.
- Improved spacing.
- Better alignment with the overall detail screen design.

### Characters

Redesigned the character section with:

- Search functionality.
- List-based presentation for improved information density.
- Better usability when browsing large character casts.

### Add to List Bottom Sheet

Replaced the previous standalone Add to List screen with a reusable `ModalBottomSheet`.

Features include:

- Integrated Add to List flow directly within the detail screen.
- Smooth transitions and animations.
- Custom sheet styling.
- Modular bottom sheet components.
- Consistent typography and Material 3 styling.
- ViewModel-driven state management.

The new implementation is available for both:

- Anime Detail
- Manga Detail

### Component Refactoring

- Replaced the inline genre implementation in the Anime Detail screen with the reusable `CompactGenreCard` component.
- Improved component reusability and consistency across detail screens.

### User Feedback

Simplified status feedback by replacing SnackBar messages with Toast notifications for lightweight user interactions.

## Result

This PR modernizes the Manga Detail experience with a cleaner, more immersive UI while introducing a reusable Add to List bottom sheet shared between Anime and Manga detail screens. The new architecture improves component reuse, streamlines user interactions, and provides a more polished experience throughout the application.